### PR TITLE
docs: add intermediate git commits after specs and coding steps

### DIFF
--- a/.agents-brain/agent-0-orchestrator.md
+++ b/.agents-brain/agent-0-orchestrator.md
@@ -22,6 +22,8 @@ Read `.agents-brain/agent-1-specs.md` and spawn a subagent using the Task tool w
 
 Wait for `.agents-output/specs.md` to end with `status: ready`.
 
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit specs output).
+
 Use AskUserQuestion to show the user a summary of `.agents-output/specs.md` and ask for approval before proceeding to coding.
 If the user does not approve, stop the pipeline and report why.
 
@@ -38,6 +40,7 @@ If `status: review specs`:
 
 If `status: ready`:
 
+- Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 4 only** (commit code changes).
 - Use AskUserQuestion to show the user a summary of `.agents-output/code-ready.md` and ask for approval before testing.
 - If the user does not approve, stop the pipeline.
 
@@ -59,6 +62,6 @@ If MAX_RETRIES is exceeded at any step, stop the pipeline and report the failure
 
 ### Step 4 — Versioning
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit and push the work on the branch created in Step 0).
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 5 only** (commit test results and push the branch).
 
 Report the branch name and commit message to the user when done.

--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -1,6 +1,6 @@
 # I am a Versionning Agent
 
-The orchestrator will call me twice: once before specs (Tasks 1–2) and once after testing (Task 3). Execute only the tasks the orchestrator instructs.
+The orchestrator will call me multiple times during the pipeline. Execute only the tasks the orchestrator instructs.
 
 ## Task 1: Make Sure Local Repository Is Up-to-date
 
@@ -12,13 +12,29 @@ Read `.agents-output/user-requests.md` to understand the nature of the change (f
 
 Create the branch according to `CLAUDE.md` instructions before any other agent writes files.
 
-## Task 3: Commit the work done
+## Task 3: Commit specs output
+
+Stage `.agents-output/specs.md` and commit it on the current branch with a short message such as:
+
+```
+chore: record specs for [short description]
+```
+
+Do not push yet.
+
+## Task 4: Commit code changes
+
+Read `.agents-output/code-ready.md` (latest section) for the list of files changed.
+
+Stage those source files plus `.agents-output/code-ready.md` and commit on the current branch with a message summarising the implementation based on `.agents-output/specs.md`. Do not push yet.
+
+## Task 5: Commit test results and push
 
 Read `.agents-output/test-results.md`.
 
 If the last line is `status: passed`:
 
-- Stage only the files listed in `.agents-output/code-ready.md` and the `.agents-output/` files.
+- Stage the test files introduced or modified and `.agents-output/test-results.md`.
 - Write a meaningful commit message that summarises the change based on `.agents-output/specs.md` within Git recommended message length. Put anything beyond the commit message limit into the commit description.
 - Commit on the current feature branch — never commit directly to main.
 - Push the branch to origin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,20 @@ The user never needs to run a command — just describe what they want and the p
 ```
 [user-requests.md]
        ↓
+Versioning agent → branch
+       ↓
   Specs agent → specs.md
+       ↓
+Versioning agent → commit specs
        ↓ ← human approval
   Coder agent → code-ready.md
        ↓           ↑ status: review specs (loops back)
+       ↓
+Versioning agent → commit code
        ↓ ← human approval
  Tester agent → test-results.md
        ↓           ↑ status: failed (loops back to coder)
-Versioning agent → branch + commit + push
+Versioning agent → commit tests + push
 ```
 
 Human approval gates pause the pipeline after specs and after coding. The orchestrator retries failed loops up to 3 times before aborting.


### PR DESCRIPTION
The versioning agent is now called after the specs agent and after the coder agent to commit their outputs before the human approval gate. Final push happens after tests pass (Task 5, previously Task 3).