### PR TITLE
chore: update .gitignore and README testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Results are written to a CSV file with the following columns:
 
 ## Testing
 
+### Unit tests
+
+```bash
+python -m pytest tests/ -v
+```
+
+### Integration test
+
 A sample website is available to test the tool against:
 
 ```plaintext
@@ -126,6 +134,12 @@ Human approval gates pause the pipeline after specs and after coding.
 | New feature | `feature/`    |
 | Bug fix     | `fix/`        |
 | Docs only   | `docs/`       |
+
+### Manual testing
+
+```bash
+python src/checker.py https://deadlinkchecker-sample-website.netlify.app
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

- Added `scans*` to `.gitignore` so local scan output is never committed
- Added unit test command (`python -m pytest tests/ -v`) to README
- Filled in the empty Manual testing stub with the sample site command

## Test plan

- [x] Verify `scans/` folder is ignored by git after a local scan run
- [x] Verify README renders correctly on GitHub

🤖 Generated with Claude Code