### PR TITLE
feat: add --include-3xx-status-code flag to email notifications #35

### DIFF
--- a/.agents-output/0-user-requests/2026-02-26-13-01-39-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
+++ b/.agents-output/0-user-requests/2026-02-26-13-01-39-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
@@ -1,0 +1,7 @@
+## 2026-02-26 — Issue #35: Add option to exclude 3xx status codes from email notifications
+
+Add a boolean CLI flag that, when present, includes links with HTTP 3xx status codes in the email notification.
+
+- The flag controls email content only — the CSV output must still list all 3xx links regardless.
+- Default behaviour (flag absent): 3xx links are excluded from the email notification.
+- Flag present: 3xx links are included in the email notification alongside other non-200 results.

--- a/.agents-output/1-business-specifications/2026-02-26-13-01-39-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
+++ b/.agents-output/1-business-specifications/2026-02-26-13-01-39-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
@@ -1,0 +1,103 @@
+# Business Specification — Issue #35: Add option to include 3xx results in email notifications
+
+## Context
+
+The email notification currently reports all non-200 HTTP results. 3xx (redirect) status codes are included in that set. Users who consider redirects acceptable want to suppress them from email notifications without losing them in the CSV report.
+
+## Scope
+
+This change affects email notification content only. CSV output and console output are unchanged.
+
+## Rules and Examples
+
+### Rule 1: Default behaviour excludes 3xx results from email
+
+When `--notify-email` is provided and `--include-3xx-status-code` is absent, the email table lists only results whose status code is not 200 and not in the 3xx range (300–399).
+
+Example — scan returns 200, 301, 302, 404, 500, other errors; flag absent:
+
+- Email table contains: 404, 500 and Error (no HTTP Status code) rows only.
+- Email subject line "non-200 result(s)" count reflects only the rows shown (2 in this example).
+- CSV contains all six rows.
+
+Example — scan returns 200, 301, 302 only; flag absent:
+
+- No non-200-non-3xx results exist.
+- Email table is empty (no rows rendered).
+- Subject line shows 0 non-200 result(s).
+- Email is still sent (not suppressed entirely).
+- CSV contains all three rows.
+
+### Rule 2: `--include-3xx-status-code` flag causes 3xx results to appear in email
+
+When `--notify-email` is provided and `--include-3xx-status-code` is present, the email table lists all results whose status code is not 200, including 3xx codes.
+
+Example — scan returns 200, 301, 302, 404, 500; flag present:
+
+- Email table contains: 301, 302, 404, 500 rows.
+- Subject line "non-200 result(s)" count is 4.
+- CSV contains all five rows.
+
+Example — scan returns 200 and 301 only; flag present:
+
+- Email table contains: 301 row only.
+- Subject line count is 1.
+- CSV contains both rows.
+
+### Rule 3: `--include-3xx-status-code` has no effect when `--notify-email` is absent
+
+When `--notify-email` is not provided, no email is sent regardless of `--include-3xx-status-code`. The flag is silently ignored.
+
+Example — `--include-3xx-status-code` passed without `--notify-email`:
+
+- No email is attempted.
+- CSV output is unchanged.
+
+### Rule 4: `--include-3xx-status-code` has no effect on CSV output
+
+The CSV always contains every discovered link with its status, regardless of `--include-3xx-status-code`.
+
+Example — scan returns 200, 301, 404; flag present:
+
+- CSV rows: 200, 301, 404.
+
+Example — scan returns 200, 301, 404; flag absent:
+
+- CSV rows: 200, 301, 404.
+
+### Rule 5: All-200 scan with flag present or absent
+
+When every checked link returns 200, the email table is empty under both flag states.
+
+Example — scan returns 200 only; flag present:
+
+- Email table is empty.
+- Subject line shows 0 non-200 result(s).
+
+Example — scan returns 200 only; flag absent:
+
+- Email table is empty.
+- Subject line shows 0 non-200 result(s).
+
+## New CLI Flag
+
+| Property | Value                                                  |
+| -------- | ------------------------------------------------------ |
+| Name     | `--include-3xx-status-code`                            |
+| Type     | Boolean flag (store_true)                              |
+| Default  | absent (false)                                         |
+| Scope    | Email content only                                     |
+| Requires | Has no effect unless `--notify-email` is also provided |
+
+## Email Subject Line
+
+The "non-200 result(s)" count in the subject line must match the number of rows rendered in the email table, not the total number of non-200 results in the scan. When `--include-3xx-status-code` is absent, 3xx results are excluded from both the count and the table.
+
+## Out of Scope
+
+- The flag does not affect which links are crawled or checked.
+- The flag does not affect the CSV output.
+- The flag does not affect the Markdown summary written to disk.
+- No new environment variables are introduced.
+
+status: ready

--- a/.agents-output/2-technical-specifications/2026-02-26-13-08-18-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
+++ b/.agents-output/2-technical-specifications/2026-02-26-13-08-18-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
@@ -1,0 +1,91 @@
+# Technical Specification — Issue #35: Add option to include 3xx results in email notifications
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/argument_parser.py` | Added `--include-3xx-status-code` boolean flag (`store_true`) |
+| `src/checker.py` | Passed `args.include_3xx_status_code` to `emailer.send_email_notification` |
+| `src/emailer.py` | Added `_is_3xx()` helper and `include_3xx` parameter to `send_email_notification`; filter logic applied before building email |
+
+## Implementation details
+
+### `src/argument_parser.py`
+
+Added after `--notify-email`:
+
+```python
+parser.add_argument(
+    "--include-3xx-status-code",
+    action="store_true",
+    default=False,
+    help=(
+        "Include 3xx redirect results in the email notification table. "
+        "By default, 3xx results are excluded from the email (but still appear in the CSV). "
+        "Has no effect when --notify-email is absent."
+    ),
+)
+```
+
+argparse converts `--include-3xx-status-code` to `args.include_3xx_status_code` automatically.
+
+### `src/checker.py`
+
+`_maybe_send_notification` now passes the flag value:
+
+```python
+emailer.send_email_notification(
+    results,
+    website,
+    scan_timestamp,
+    len(results),
+    args.notify_email,
+    args.include_3xx_status_code,
+)
+```
+
+No other changes in `checker.py`. CSV writing is untouched.
+
+### `src/emailer.py`
+
+Added private helper above `send_email_notification`:
+
+```python
+def _is_3xx(status: str) -> bool:
+    return len(status) == 3 and status.startswith("3") and status.isdigit()
+```
+
+`send_email_notification` gains one new parameter with a safe default:
+
+```python
+def send_email_notification(
+    results: list[tuple[str, str, str]],
+    website: str,
+    timestamp: str,
+    total_links: int,
+    notify_email: str,
+    include_3xx: bool = False,
+) -> None:
+```
+
+Filter applied before building the email (replaces the old one-liner):
+
+```python
+non_200_results = [
+    row for row in results
+    if row[2] != "200" and (include_3xx or not _is_3xx(row[2]))
+]
+```
+
+- When `include_3xx=False` (default): rows where `_is_3xx(status)` is True are excluded.
+- When `include_3xx=True`: all non-200 rows are included, 3xx among them.
+- `non_200_count = len(non_200_results)` is derived from the filtered list, so the subject-line count always matches the rendered row count.
+
+## Invariants preserved
+
+- `reporter.py` is unchanged — CSV always contains every result.
+- `reporter.write_markdown_summary` is unchanged.
+- The `default=False` on `include_3xx` means existing call sites (e.g. tests) that omit the parameter continue to work without modification.
+- The `_is_3xx` guard (`len == 3`, `startswith("3")`, `isdigit()`) correctly handles `ERROR:*` statuses, which are neither 200 nor 3xx and are always included in the email.
+
+status: ready

--- a/.agents-output/3-test-results/2026-02-26-13-13-31-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
+++ b/.agents-output/3-test-results/2026-02-26-13-13-31-issue-35-add-option-to-exclude-3xx-from-email-notifications.md
@@ -1,0 +1,137 @@
+# Test Results — Issue #35: Add option to exclude 3xx from email notifications
+
+## Pre-existing test suite
+
+Ran before any new tests to establish baseline.
+
+- Suite: `tests/` (all files)
+- Runner: `python -m pytest tests/ -v`
+- Result: **85 passed, 0 failed**
+
+## New test file
+
+`tests/test_issue_35_include_3xx.py`
+
+46 new tests across 8 test classes.
+
+## Test cases and results
+
+### TestDefaultExcludes3xx — flag absent, 3xx excluded from email
+
+| Test | Result |
+|---|---|
+| `test_3xx_rows_absent_from_non_200_results` | PASSED |
+| `test_404_and_500_rows_present` | PASSED |
+| `test_200_row_absent` | PASSED |
+| `test_subject_count_excludes_3xx` | PASSED |
+| `test_subject_count_matches_row_count` | PASSED |
+
+Verified: with `include_3xx=False` (default), 301 and 302 rows are absent from `non_200_results`; 404, 500, and ERROR rows remain; subject count is 3 (404 + 500 + ERROR).
+
+### TestFlagPresentIncludes3xx — flag present, 3xx included
+
+| Test | Result |
+|---|---|
+| `test_3xx_rows_present_in_non_200_results` | PASSED |
+| `test_404_500_and_error_rows_present` | PASSED |
+| `test_200_row_still_absent` | PASSED |
+| `test_subject_count_includes_3xx` | PASSED |
+| `test_subject_count_matches_row_count` | PASSED |
+
+Verified: with `include_3xx=True`, 301 and 302 appear in `non_200_results`; count in subject is 5 (301 + 302 + 404 + 500 + ERROR); 200 never appears.
+
+### TestOnly3xxResultsFlagAbsent — only 3xx non-200s exist, flag absent
+
+| Test | Result |
+|---|---|
+| `test_non_200_results_is_empty` | PASSED |
+| `test_subject_count_is_zero` | PASSED |
+| `test_subject_count_matches_row_count` | PASSED |
+
+Verified: when all non-200 rows are 3xx and flag is absent, `non_200_results` is empty and subject shows `0 non-200 result(s)`.
+
+### TestErrorRowsAlwaysIncluded — ERROR:* strings always present
+
+| Test | Result |
+|---|---|
+| `test_error_rows_present_flag_absent` | PASSED |
+| `test_error_rows_present_flag_present` | PASSED |
+| `test_3xx_excluded_but_errors_included_flag_absent` | PASSED |
+| `test_only_error_results_flag_absent` | PASSED |
+
+Verified: `ERROR:ConnectionError` and `ERROR:Timeout` appear in `non_200_results` regardless of `include_3xx`; 301 is correctly excluded while errors remain when flag is absent.
+
+### TestSubjectCountMatchesRowCount — subject count always equals row count
+
+| Test | Result |
+|---|---|
+| `test_flag_absent_mixed_results` | PASSED (count=3) |
+| `test_flag_present_mixed_results` | PASSED (count=5) |
+| `test_flag_absent_all_3xx` | PASSED (count=0) |
+| `test_flag_present_one_3xx` | PASSED (count=1) |
+
+Verified: subject count string matches `len(non_200_results)` in all four combinations tested.
+
+### TestAll200Results — all-200 scan, both flag states
+
+| Test | Result |
+|---|---|
+| `test_empty_table_flag_absent` | PASSED |
+| `test_empty_table_flag_present` | PASSED |
+| `test_subject_count_zero_flag_absent` | PASSED |
+| `test_subject_count_zero_flag_present` | PASSED |
+
+Verified: all-200 results yield empty `non_200_results` and `0 non-200 result(s)` in subject under both flag states.
+
+### TestIs3xx — _is_3xx helper boundary conditions
+
+| Test | Result |
+|---|---|
+| `test_300_is_3xx` | PASSED |
+| `test_301_is_3xx` | PASSED |
+| `test_302_is_3xx` | PASSED |
+| `test_307_is_3xx` | PASSED |
+| `test_308_is_3xx` | PASSED |
+| `test_399_is_3xx` | PASSED |
+| `test_200_is_not_3xx` | PASSED |
+| `test_400_is_not_3xx` | PASSED |
+| `test_404_is_not_3xx` | PASSED |
+| `test_500_is_not_3xx` | PASSED |
+| `test_error_string_is_not_3xx` | PASSED |
+| `test_error_timeout_is_not_3xx` | PASSED |
+| `test_short_string_is_not_3xx` | PASSED |
+| `test_long_string_is_not_3xx` | PASSED |
+| `test_non_digit_3xx_like_is_not_3xx` | PASSED |
+| `test_empty_string_is_not_3xx` | PASSED |
+
+Verified: guard conditions (len==3, startswith("3"), isdigit()) correctly classify all boundary inputs. `ERROR:*` strings are correctly identified as non-3xx.
+
+### TestArgumentParserInclude3xxFlag — CLI flag registration
+
+| Test | Result |
+|---|---|
+| `test_include_3xx_status_code_default_is_false` | PASSED |
+| `test_include_3xx_status_code_flag_sets_true` | PASSED |
+| `test_include_3xx_status_code_is_bool` | PASSED |
+| `test_include_3xx_flag_independent_of_notify_email` | PASSED |
+| `test_include_3xx_false_when_notify_email_also_absent` | PASSED |
+
+Verified: flag defaults to `False`; providing `--include-3xx-status-code` sets it to `True`; it is a `bool`; it is independent of `--notify-email`.
+
+## Full suite after new tests
+
+- Total: **131 passed, 0 failed**
+- No regressions introduced.
+
+## Observations
+
+The implementation in `src/emailer.py`, `src/argument_parser.py`, and `src/checker.py` conforms exactly to the technical specification:
+
+- `_is_3xx()` helper correctly identifies 3xx HTTP status strings and rejects `ERROR:*` and non-numeric patterns.
+- Filter expression `row[2] != "200" and (include_3xx or not _is_3xx(row[2]))` correctly includes/excludes 3xx rows based on the flag.
+- `non_200_count = len(non_200_results)` is derived from the already-filtered list, guaranteeing subject count always matches rendered row count.
+- `include_3xx` parameter has `default=False`, preserving backward compatibility for existing callers that omit it.
+- `argument_parser.py` registers `--include-3xx-status-code` as `store_true` with `default=False`; argparse converts the dashed name to `include_3xx_status_code` automatically; `checker.py` passes `args.include_3xx_status_code` to `emailer.send_email_notification`.
+- CSV output is untouched; only email content is affected.
+
+status: passed

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,9 @@
       "Bash(gh issue:*)",
       "Bash(git:*)",
       "Bash(gh pr:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(powershell:*)",
+      "Bash(cd /e/Git/GitHub/deadlinkchecker && /e/Applications/Scoop/apps/python/current/python.exe -m pytest tests/ -v 2>&1)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ python src/checker.py https://example.com --notify-email you@example.com
 
 See [Resend website](https://resend.com/) for setting up your account.
 
+When using `npm run scan-with-email`, make sure to add the environment variables:
+
+```sh
+export RESEND_API_KEY=re_xxxxx && export RESEND_FROM_ADDRESS=noreply@yourdomain.fr && npm run scan-with-email random@yopmail.com
+```
+
 ## Output Format
 
 Results are written to a CSV file with the following columns:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "python -m pytest tests/ -v"
+    "test": "python -m pytest tests/ -v",
+    "scan": "python src/checker.py https://deadlinkchecker-sample-website.netlify.app/",
+    "scan-with-email": "python src/checker.py https://deadlinkchecker-sample-website.netlify.app/ --notify-email "
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/argument_parser.py
+++ b/src/argument_parser.py
@@ -43,4 +43,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Requires RESEND_API_KEY and RESEND_FROM_ADDRESS environment variables."
         ),
     )
+    parser.add_argument(
+        "--include-3xx-status-code",
+        action="store_true",
+        default=False,
+        help=(
+            "Include 3xx redirect results in the email notification table. "
+            "By default, 3xx results are excluded from the email (but still appear in the CSV). "
+            "Has no effect when --notify-email is absent."
+        ),
+    )
     return parser

--- a/src/checker.py
+++ b/src/checker.py
@@ -22,7 +22,14 @@ def _maybe_send_notification(
 ) -> None:
     if args.notify_email is None:
         return
-    emailer.send_email_notification(results, website, scan_timestamp, len(results), args.notify_email)
+    emailer.send_email_notification(
+        results,
+        website,
+        scan_timestamp,
+        len(results),
+        args.notify_email,
+        args.include_3xx_status_code,
+    )
 
 
 def main() -> None:

--- a/src/emailer.py
+++ b/src/emailer.py
@@ -68,12 +68,17 @@ def _send_via_resend(
         )
 
 
+def _is_3xx(status: str) -> bool:
+    return len(status) == 3 and status.startswith("3") and status.isdigit()
+
+
 def send_email_notification(
     results: list[tuple[str, str, str]],
     website: str,
     timestamp: str,
     total_links: int,
     notify_email: str,
+    include_3xx: bool = False,
 ) -> None:
     """Send an email notification with scan results via the Resend API.
 
@@ -89,6 +94,9 @@ def send_email_notification(
         Total number of links checked.
     notify_email:
         Recipient email address.
+    include_3xx:
+        When False (default), 3xx redirect results are excluded from the email
+        table and subject-line count. When True, they are included.
     """
     if _RESEND_API_KEY is None:
         print("Warning: RESEND_API_KEY is not set; notification skipped.", file=sys.stderr)
@@ -97,7 +105,10 @@ def send_email_notification(
         print("Warning: RESEND_FROM_ADDRESS is not set; notification skipped.", file=sys.stderr)
         return
     resend.api_key = _RESEND_API_KEY
-    non_200_results = [row for row in results if row[2] != "200"]
+    non_200_results = [
+        row for row in results
+        if row[2] != "200" and (include_3xx or not _is_3xx(row[2]))
+    ]
     non_200_count = len(non_200_results)
     subject = "Dead link scan: {} — {} non-200 result(s)".format(website, non_200_count)
     body = _build_email_html(website, timestamp, total_links, non_200_results)

--- a/tests/test_issue_35_include_3xx.py
+++ b/tests/test_issue_35_include_3xx.py
@@ -1,0 +1,418 @@
+"""Tests for issue #35 — --include-3xx-status-code flag.
+
+Covers:
+1. Default (flag absent): 3xx rows excluded from email, CSV unaffected.
+2. Flag present: 3xx rows included in email.
+3. Flag absent + only 3xx non-200 results: email table empty, count = 0.
+4. ERROR:* strings always appear regardless of flag.
+5. Subject-line count matches rendered row count in both flag states.
+6. All-200 scan: email table empty regardless of flag.
+7. _is_3xx helper boundary conditions.
+8. argument_parser: --include-3xx-status-code flag defaults and stores correctly.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC_DIR = os.path.join(PROJECT_ROOT, "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import emailer
+import argument_parser
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ENV_PATCHES = dict(
+    _RESEND_API_KEY="test-api-key",
+    _RESEND_FROM_ADDRESS="from@example.com",
+)
+
+_MIXED_RESULTS = [
+    ("https://example.com/", "", "200"),
+    ("https://example.com/redirect", "https://example.com/", "301"),
+    ("https://example.com/moved", "https://example.com/", "302"),
+    ("https://example.com/gone", "https://example.com/", "404"),
+    ("https://example.com/error", "https://example.com/", "500"),
+    ("https://example.com/broken", "https://example.com/", "ERROR:ConnectionError"),
+]
+
+
+def _call_send(results, include_3xx=False):
+    """Call send_email_notification with mocked env-vars; return captured subject and non_200_results."""
+    captured = {}
+
+    def fake_build_html(website, timestamp, total_links, non_200_results):
+        captured["non_200_results"] = non_200_results
+        return "<p>body</p>"
+
+    def fake_send_via_resend(notify_email, from_address, subject, body):
+        captured["subject"] = subject
+
+    with patch.object(emailer, "_RESEND_API_KEY", _ENV_PATCHES["_RESEND_API_KEY"]), \
+         patch.object(emailer, "_RESEND_FROM_ADDRESS", _ENV_PATCHES["_RESEND_FROM_ADDRESS"]), \
+         patch("emailer._build_email_html", side_effect=fake_build_html), \
+         patch("emailer._send_via_resend", side_effect=fake_send_via_resend):
+        emailer.send_email_notification(
+            results=results,
+            website="example.com",
+            timestamp="2026-02-26T13-00-00",
+            total_links=len(results),
+            notify_email="user@example.com",
+            include_3xx=include_3xx,
+        )
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Test Case 1: Default behaviour (flag absent) — 3xx excluded from email
+# ---------------------------------------------------------------------------
+
+class TestDefaultExcludes3xx(unittest.TestCase):
+    """With include_3xx=False (default) 3xx rows must not appear in email."""
+
+    def setUp(self):
+        self.captured = _call_send(_MIXED_RESULTS, include_3xx=False)
+        self.non_200 = self.captured["non_200_results"]
+
+    def test_3xx_rows_absent_from_non_200_results(self):
+        """301 and 302 rows must not be in non_200_results when flag is absent."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertNotIn("301", statuses)
+        self.assertNotIn("302", statuses)
+
+    def test_404_and_500_rows_present(self):
+        """404 and 500 rows must still appear in non_200_results."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertIn("404", statuses)
+        self.assertIn("500", statuses)
+
+    def test_200_row_absent(self):
+        """200 row is never included in non_200_results."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertNotIn("200", statuses)
+
+    def test_subject_count_excludes_3xx(self):
+        """Subject-line count equals the number of non-3xx, non-200 rows (including errors)."""
+        # 404, 500, ERROR:ConnectionError = 3 rows
+        subject = self.captured["subject"]
+        self.assertIn("3 non-200 result(s)", subject)
+
+    def test_subject_count_matches_row_count(self):
+        """Subject count matches len(non_200_results)."""
+        subject = self.captured["subject"]
+        expected = str(len(self.non_200))
+        self.assertIn(expected + " non-200 result(s)", subject)
+
+
+# ---------------------------------------------------------------------------
+# Test Case 2: Flag present — 3xx included in email
+# ---------------------------------------------------------------------------
+
+class TestFlagPresentIncludes3xx(unittest.TestCase):
+    """With include_3xx=True all non-200 rows (including 3xx) must appear."""
+
+    def setUp(self):
+        self.captured = _call_send(_MIXED_RESULTS, include_3xx=True)
+        self.non_200 = self.captured["non_200_results"]
+
+    def test_3xx_rows_present_in_non_200_results(self):
+        """301 and 302 rows must be in non_200_results when flag is present."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertIn("301", statuses)
+        self.assertIn("302", statuses)
+
+    def test_404_500_and_error_rows_present(self):
+        """404, 500, and ERROR rows must also be present."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertIn("404", statuses)
+        self.assertIn("500", statuses)
+        self.assertIn("ERROR:ConnectionError", statuses)
+
+    def test_200_row_still_absent(self):
+        """200 row is never in non_200_results even when flag is present."""
+        statuses = [row[2] for row in self.non_200]
+        self.assertNotIn("200", statuses)
+
+    def test_subject_count_includes_3xx(self):
+        """Subject-line count is 5 (301, 302, 404, 500, ERROR) when flag present."""
+        subject = self.captured["subject"]
+        self.assertIn("5 non-200 result(s)", subject)
+
+    def test_subject_count_matches_row_count(self):
+        """Subject count matches len(non_200_results)."""
+        subject = self.captured["subject"]
+        expected = str(len(self.non_200))
+        self.assertIn(expected + " non-200 result(s)", subject)
+
+
+# ---------------------------------------------------------------------------
+# Test Case 3: Flag absent + only 3xx non-200 results => email table empty
+# ---------------------------------------------------------------------------
+
+class TestOnly3xxResultsFlagAbsent(unittest.TestCase):
+    """When all non-200 results are 3xx and flag is absent, table is empty, count = 0."""
+
+    _ONLY_3XX = [
+        ("https://example.com/", "", "200"),
+        ("https://example.com/a", "https://example.com/", "301"),
+        ("https://example.com/b", "https://example.com/", "302"),
+        ("https://example.com/c", "https://example.com/", "307"),
+    ]
+
+    def setUp(self):
+        self.captured = _call_send(self._ONLY_3XX, include_3xx=False)
+        self.non_200 = self.captured["non_200_results"]
+
+    def test_non_200_results_is_empty(self):
+        """non_200_results list is empty when only 3xx statuses exist and flag absent."""
+        self.assertEqual(self.non_200, [])
+
+    def test_subject_count_is_zero(self):
+        """Subject-line count is 0 when only 3xx results exist and flag absent."""
+        subject = self.captured["subject"]
+        self.assertIn("0 non-200 result(s)", subject)
+
+    def test_subject_count_matches_row_count(self):
+        """Subject count matches len(non_200_results) = 0."""
+        subject = self.captured["subject"]
+        self.assertIn("0 non-200 result(s)", subject)
+        self.assertEqual(len(self.non_200), 0)
+
+
+# ---------------------------------------------------------------------------
+# Test Case 4: ERROR:* strings always appear regardless of flag
+# ---------------------------------------------------------------------------
+
+class TestErrorRowsAlwaysIncluded(unittest.TestCase):
+    """ERROR:* statuses must appear in email regardless of include_3xx flag."""
+
+    _ERROR_RESULTS = [
+        ("https://example.com/", "", "200"),
+        ("https://example.com/a", "https://example.com/", "301"),
+        ("https://example.com/b", "https://example.com/", "ERROR:ConnectionError"),
+        ("https://example.com/c", "https://example.com/", "ERROR:Timeout"),
+    ]
+
+    def test_error_rows_present_flag_absent(self):
+        """ERROR:* rows present in non_200_results when include_3xx=False."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx=False)
+        statuses = [row[2] for row in captured["non_200_results"]]
+        self.assertIn("ERROR:ConnectionError", statuses)
+        self.assertIn("ERROR:Timeout", statuses)
+
+    def test_error_rows_present_flag_present(self):
+        """ERROR:* rows present in non_200_results when include_3xx=True."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx=True)
+        statuses = [row[2] for row in captured["non_200_results"]]
+        self.assertIn("ERROR:ConnectionError", statuses)
+        self.assertIn("ERROR:Timeout", statuses)
+
+    def test_3xx_excluded_but_errors_included_flag_absent(self):
+        """301 excluded but ERROR rows remain when flag absent."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx=False)
+        statuses = [row[2] for row in captured["non_200_results"]]
+        self.assertNotIn("301", statuses)
+        self.assertIn("ERROR:ConnectionError", statuses)
+
+    def test_only_error_results_flag_absent(self):
+        """When only ERROR rows and 200 exist with flag absent, count equals error count."""
+        results = [
+            ("https://example.com/", "", "200"),
+            ("https://example.com/a", "https://example.com/", "ERROR:ConnectionError"),
+        ]
+        captured = _call_send(results, include_3xx=False)
+        self.assertEqual(len(captured["non_200_results"]), 1)
+        self.assertIn("1 non-200 result(s)", captured["subject"])
+
+
+# ---------------------------------------------------------------------------
+# Test Case 5: Subject-line count matches rendered row count (both states)
+# ---------------------------------------------------------------------------
+
+class TestSubjectCountMatchesRowCount(unittest.TestCase):
+    """Subject-line count must always equal the number of rows that will be rendered."""
+
+    def _subject_count_matches(self, results, include_3xx):
+        captured = _call_send(results, include_3xx=include_3xx)
+        expected_count = len(captured["non_200_results"])
+        expected_str = "{} non-200 result(s)".format(expected_count)
+        self.assertIn(expected_str, captured["subject"])
+        return expected_count
+
+    def test_flag_absent_mixed_results(self):
+        """Count in subject matches non_200_results length with flag absent."""
+        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx=False)
+        # 404 + 500 + ERROR = 3
+        self.assertEqual(count, 3)
+
+    def test_flag_present_mixed_results(self):
+        """Count in subject matches non_200_results length with flag present."""
+        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx=True)
+        # 301 + 302 + 404 + 500 + ERROR = 5
+        self.assertEqual(count, 5)
+
+    def test_flag_absent_all_3xx(self):
+        """Count is 0 and matches subject when all non-200s are 3xx, flag absent."""
+        results = [
+            ("https://example.com/", "", "200"),
+            ("https://example.com/r", "https://example.com/", "301"),
+        ]
+        count = self._subject_count_matches(results, include_3xx=False)
+        self.assertEqual(count, 0)
+
+    def test_flag_present_one_3xx(self):
+        """Count is 1 when one 3xx result, flag present."""
+        results = [
+            ("https://example.com/", "", "200"),
+            ("https://example.com/r", "https://example.com/", "301"),
+        ]
+        count = self._subject_count_matches(results, include_3xx=True)
+        self.assertEqual(count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Test Case 6: All-200 scan — email table empty regardless of flag
+# ---------------------------------------------------------------------------
+
+class TestAll200Results(unittest.TestCase):
+    """When every link returns 200, non_200_results is empty under both flag states."""
+
+    _ALL_200 = [
+        ("https://example.com/", "", "200"),
+        ("https://example.com/about", "https://example.com/", "200"),
+        ("https://example.com/contact", "https://example.com/", "200"),
+    ]
+
+    def test_empty_table_flag_absent(self):
+        """non_200_results is empty with all-200 scan and flag absent."""
+        captured = _call_send(self._ALL_200, include_3xx=False)
+        self.assertEqual(captured["non_200_results"], [])
+
+    def test_empty_table_flag_present(self):
+        """non_200_results is empty with all-200 scan and flag present."""
+        captured = _call_send(self._ALL_200, include_3xx=True)
+        self.assertEqual(captured["non_200_results"], [])
+
+    def test_subject_count_zero_flag_absent(self):
+        """Subject shows 0 non-200 result(s) with all-200 scan, flag absent."""
+        captured = _call_send(self._ALL_200, include_3xx=False)
+        self.assertIn("0 non-200 result(s)", captured["subject"])
+
+    def test_subject_count_zero_flag_present(self):
+        """Subject shows 0 non-200 result(s) with all-200 scan, flag present."""
+        captured = _call_send(self._ALL_200, include_3xx=True)
+        self.assertIn("0 non-200 result(s)", captured["subject"])
+
+
+# ---------------------------------------------------------------------------
+# Test Case 7: _is_3xx helper boundary conditions
+# ---------------------------------------------------------------------------
+
+class TestIs3xx(unittest.TestCase):
+    """Unit tests for emailer._is_3xx()."""
+
+    def test_300_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("300"))
+
+    def test_301_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("301"))
+
+    def test_302_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("302"))
+
+    def test_307_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("307"))
+
+    def test_308_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("308"))
+
+    def test_399_is_3xx(self):
+        self.assertTrue(emailer._is_3xx("399"))
+
+    def test_200_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("200"))
+
+    def test_400_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("400"))
+
+    def test_404_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("404"))
+
+    def test_500_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("500"))
+
+    def test_error_string_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("ERROR:ConnectionError"))
+
+    def test_error_timeout_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("ERROR:Timeout"))
+
+    def test_short_string_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("3"))
+
+    def test_long_string_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx("3000"))
+
+    def test_non_digit_3xx_like_is_not_3xx(self):
+        """'3xx' is not a valid 3-char all-digit string starting with 3."""
+        self.assertFalse(emailer._is_3xx("3xx"))
+
+    def test_empty_string_is_not_3xx(self):
+        self.assertFalse(emailer._is_3xx(""))
+
+
+# ---------------------------------------------------------------------------
+# Test Case 8: argument_parser --include-3xx-status-code flag
+# ---------------------------------------------------------------------------
+
+class TestArgumentParserInclude3xxFlag(unittest.TestCase):
+    """Tests for the --include-3xx-status-code CLI flag in argument_parser."""
+
+    def _parse(self, argv):
+        return argument_parser.build_arg_parser().parse_args(argv)
+
+    def test_include_3xx_status_code_default_is_false(self):
+        """--include-3xx-status-code defaults to False when omitted."""
+        args = self._parse(["https://example.com/"])
+        self.assertFalse(args.include_3xx_status_code)
+
+    def test_include_3xx_status_code_flag_sets_true(self):
+        """--include-3xx-status-code sets attribute to True when provided."""
+        args = self._parse(["https://example.com/", "--include-3xx-status-code"])
+        self.assertTrue(args.include_3xx_status_code)
+
+    def test_include_3xx_status_code_is_bool(self):
+        """include_3xx_status_code is a boolean value."""
+        args = self._parse(["https://example.com/"])
+        self.assertIsInstance(args.include_3xx_status_code, bool)
+
+    def test_include_3xx_flag_independent_of_notify_email(self):
+        """--include-3xx-status-code can be set with or without --notify-email."""
+        args_with = self._parse([
+            "https://example.com/",
+            "--notify-email", "user@example.com",
+            "--include-3xx-status-code",
+        ])
+        args_without = self._parse([
+            "https://example.com/",
+            "--include-3xx-status-code",
+        ])
+        self.assertTrue(args_with.include_3xx_status_code)
+        self.assertTrue(args_without.include_3xx_status_code)
+
+    def test_include_3xx_false_when_notify_email_also_absent(self):
+        """When neither flag is provided both default to False/None."""
+        args = self._parse(["https://example.com/"])
+        self.assertFalse(args.include_3xx_status_code)
+        self.assertIsNone(args.notify_email)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `--include-3xx-status-code` boolean CLI flag (`store_true`, absent by default)
- When absent: 3xx results are excluded from the email notification table and count
- When present: 3xx results are included alongside other non-200 results
- CSV output is unaffected regardless of the flag
- `ERROR:*` results always appear in the email regardless of the flag

## Test plan

- [x] Flag absent: 3xx rows excluded from email, non-3xx included
- [x] Flag present: 3xx rows included in email
- [x] Flag absent + only 3xx non-200 results: table empty, count = 0
- [x] `ERROR:*` strings always included regardless of flag
- [x] Subject-line count matches rendered row count in both states
- [x] All-200 scan: email table empty regardless of flag
- [x] `_is_3xx` helper boundary conditions
- [x] CLI flag registration verified
- [x] 131 tests total, all passing, no regressions

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)