### PR TITLE
feat(filter): add --keep-status-codes parameter to filter report output #39

### DIFF
--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -1,5 +1,19 @@
 # I am a Versionning Agent
 
+## Shell Setup
+
+This machine runs Windows with a bash shell. Tools are NOT on the default PATH and `export PATH=...` does not work. Always use full paths:
+
+- git: `/e/Applications/Scoop/apps/git/current/bin/git`
+- gh: `/e/Applications/Scoop/apps/gh/current/bin/gh`
+- rtk: `/e/rtk/bin/rtk`
+
+Example:
+```bash
+/e/Applications/Scoop/apps/git/current/bin/git status
+/e/Applications/Scoop/apps/git/current/bin/git checkout main
+```
+
 The orchestrator will call me multiple times during the pipeline. Execute only the tasks the orchestrator instructs.
 
 ## Commit Rules

--- a/.agents-output/0-user-requests/2026-04-17-10-00-00-issue-39-add-filter-to-keep-status-code-in-report.md
+++ b/.agents-output/0-user-requests/2026-04-17-10-00-00-issue-39-add-filter-to-keep-status-code-in-report.md
@@ -1,0 +1,25 @@
+# User Request — Issue #39
+
+## Title
+
+Add filter to keep status code in report
+
+## Source
+
+GitHub Issue: https://github.com/JeremieLitzler/deadlinkchecker/issues/39
+
+## Description
+
+Add a new CLI parameter to filter which HTTP status codes appear in the report output.
+
+Key requirements:
+- New parameter with default values of `404,500`
+- CSV output includes only rows whose status code matches the parameter values
+- Email reports display count summaries of status codes excluded from the parameter
+- Email report details table shows only status codes matching the parameter values
+- Deprecate the existing `--include-3xx-status-code` flag to consolidate functionality into the new filter parameter
+- Update tests with default and custom parameter values (e.g. `404,500,403`)
+
+## Nature of Change
+
+Feature addition + deprecation of existing flag → feature branch

--- a/.agents-output/1-business-specifications/2026-04-17-10-05-00-issue-39-add-filter-to-keep-status-code-in-report.md
+++ b/.agents-output/1-business-specifications/2026-04-17-10-05-00-issue-39-add-filter-to-keep-status-code-in-report.md
@@ -1,0 +1,70 @@
+# Business Specifications — Issue #39: Add filter to keep status code in report
+
+## Goal and Scope
+
+Introduce a new CLI parameter that controls which HTTP status codes appear in both the CSV output and the email notification. The parameter replaces the narrow `--include-3xx-status-code` flag with a general-purpose filter. The existing flag is deprecated and will emit a warning when used, pointing users to the new parameter.
+
+## New Parameter
+
+A new optional CLI parameter accepts a comma-separated list of HTTP status code strings (e.g. `404,500`). The default value is `404,500`.
+
+Name: `--keep-status-codes`
+
+## Observable Behaviours
+
+### CSV Output
+
+- Only rows whose `http_status_code` value exactly matches one of the codes in the filter are written to the CSV file.
+- Rows with status `200` are excluded by default (since `200` is not in the default filter).
+- Rows with status codes not in the filter list are silently omitted from the CSV.
+- Rows whose status is an `ERROR:*` value are always included regardless of the filter (error rows are never suppressed).
+- If the filter list is empty, all rows are written (no filtering applied).
+
+### Markdown Summary (README.md, scan-folder mode)
+
+- Same filtering rules as CSV apply: only rows matching the filter appear in the table.
+- `ERROR:*` rows are always included.
+
+### Email Notification
+
+- The details table in the email body shows only rows whose status code matches the filter (same rules as CSV).
+- `ERROR:*` rows are always included in the details table.
+- The email body includes a count summary section listing each status code that was excluded from the filter, with its occurrence count, so users retain visibility into the full picture.
+- The subject line count reflects only the rows shown in the table (filtered count).
+
+### Deprecation of `--include-3xx-status-code`
+
+- The flag remains accepted by the CLI but is marked as deprecated in the help text.
+- When supplied, the tool prints a deprecation warning to stderr: `Warning: --include-3xx-status-code is deprecated; use --keep-status-codes instead.`
+- The flag has no effect on output when `--keep-status-codes` is also supplied.
+- When `--include-3xx-status-code` is supplied alone (without `--keep-status-codes`), the tool behaves as if `--keep-status-codes 3xx,404,500` was passed — i.e. the effective filter includes all 3xx codes alongside the defaults. This preserves backward-compatible output for users who have not yet migrated.
+
+## Files to Create or Modify
+
+| File | Role |
+|---|---|
+| `src/argument_parser.py` | Add `--keep-status-codes` parameter; mark `--include-3xx-status-code` as deprecated in help text |
+| `src/checker.py` | Parse the new parameter; apply backward-compat logic for deprecated flag; pass filter down to reporter and emailer |
+| `src/reporter.py` | Apply status-code filter when writing CSV rows and Markdown table rows; always pass through `ERROR:*` rows |
+| `src/emailer.py` | Apply filter to the details table; add excluded-codes count summary section to email body; always pass through `ERROR:*` rows |
+| `tests/test_argument_parser.py` | Cover new parameter defaults, custom values, and deprecated flag |
+| `tests/test_reporter.py` | Cover filtered and unfiltered CSV/Markdown output including `ERROR:*` pass-through |
+| `tests/test_emailer.py` | Cover filtered email table and excluded-codes summary section |
+| `tests/test_checker_cli.py` | Cover end-to-end CLI invocation with default and custom filter values |
+| `tests/test_issue_35_include_3xx.py` | Update or extend to verify deprecated-flag warning and backward-compat behaviour |
+
+## Edge Cases
+
+- A user passes `--keep-status-codes ""` (empty string): all rows are written (no filter).
+- A user passes a code that matches no results (e.g. `--keep-status-codes 418`): CSV is written with zero data rows (only header).
+- A user passes `--keep-status-codes 200`: 200 rows appear in the CSV; all other codes are excluded.
+- A user passes both `--keep-status-codes 404` and `--include-3xx-status-code`: the new flag wins; deprecated flag is ignored (warning emitted).
+- A scan with only `ERROR:*` results and a filter of `404,500`: all `ERROR:*` rows still appear in the CSV and email.
+- The excluded-codes count summary in the email is omitted entirely when there are no excluded codes (i.e. the filter matches all results).
+
+## Concurrency and Performance
+
+- Filtering is applied after all link checks complete and results are fully assembled, maintaining the existing guarantee that results are written only after all checks complete.
+- No change to parallel check behaviour.
+
+status: ready

--- a/.agents-output/2-technical-specifications/2026-04-17-10-10-00-issue-39-add-filter-to-keep-status-code-in-report.md
+++ b/.agents-output/2-technical-specifications/2026-04-17-10-10-00-issue-39-add-filter-to-keep-status-code-in-report.md
@@ -1,0 +1,27 @@
+# Technical Specifications — Issue #39: Add filter to keep status code in report
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/status_filter.py` | **New.** `StatusFilter` class with `matches()` and `excluded_summary()` methods. `build_filter()` factory. `_is_3xx()` helper. |
+| `src/argument_parser.py` | Added `--keep-status-codes` (default `None`). Updated `--include-3xx-status-code` help text to mark it deprecated. |
+| `src/checker.py` | Added `_build_filter()` to construct a `StatusFilter` from CLI args (with deprecation warning + backward-compat logic). Updated `main()` to apply filter after results are collected, passing pre-filtered rows to reporter and emailer. Updated `_maybe_send_notification()` signature to accept `excluded_summary` and `total_links`. |
+| `src/reporter.py` | Removed internal `non_200` filter from `write_markdown_summary()`. Function now writes all received rows (caller is responsible for filtering). |
+| `src/emailer.py` | Replaced `include_3xx` parameter with `excluded_summary: dict`. Added `_build_excluded_summary_html()` and `_build_email_summary_lines()` helpers. Added `_build_table_html()` extractor. Updated `_build_email_html()` to include excluded-codes section. Updated `send_email_notification()` to accept pre-filtered results and excluded summary. Subject line now reads "X result(s) matching filter". |
+
+## Technical Decisions
+
+**New `status_filter` module:** The filter logic is shared by `checker.py`, and its output feeds both `reporter.py` and `emailer.py`. Placing it in its own module avoids coupling the two output modules to each other and keeps `checker.py` as the only consumer of the filter DSL.
+
+**Filtering in `checker.py`, not in reporter/emailer:** All filtering happens once in `checker.py` after results are assembled. Reporter and emailer receive already-filtered lists. This avoids duplicating filter logic across two modules and keeps output functions focused on formatting, not policy.
+
+**`--keep-status-codes` default is `None` in argparse:** Allows `checker.py` to distinguish "user explicitly passed a value" from "user omitted the flag". This is required for the backward-compat logic: when `--include-3xx-status-code` is set without `--keep-status-codes`, the effective filter expands to include 3xx codes.
+
+**`_is_3xx` kept in `emailer.py` as well:** The function is still present in `emailer.py` to avoid breaking existing tests that import it directly from there. The canonical implementation lives in `status_filter.py`.
+
+**OC exceptions documented:**
+- `main()` in `checker.py` exceeds 5 lines; it is the CLI entry point and extracting further would obscure the top-level flow.
+- `write_csv` and `write_markdown_summary` in `reporter.py` use `with` blocks that inherently add indentation; no deeper nesting is introduced.
+
+status: ready

--- a/.agents-output/3-test-results/2026-04-17-10-15-00-issue-39-add-filter-to-keep-status-code-in-report.md
+++ b/.agents-output/3-test-results/2026-04-17-10-15-00-issue-39-add-filter-to-keep-status-code-in-report.md
@@ -1,0 +1,54 @@
+# Test Results — Issue #39: Add filter to keep status code in report
+
+## Tests Run
+
+### New test file: `tests/test_status_filter.py`
+- `TestIs3xx` (8 tests) — boundary conditions for `_is_3xx()`
+- `TestStatusFilterMatches` (8 tests) — `StatusFilter.matches()` with various code/filter combinations
+- `TestStatusFilterExcludedSummary` (6 tests) — `StatusFilter.excluded_summary()` counting
+- `TestBuildFilter` (6 tests) — `build_filter()` factory
+
+### Updated: `tests/test_issue_35_include_3xx.py`
+Rewrote `_call_send` helper to use new `StatusFilter` + `send_email_notification` API. Added new test class.
+- `TestDefaultFilterExcludes3xx` (6 tests) — default filter (404,500) excludes 3xx and 200
+- `TestInclude3xxCompatIncludes3xx` (5 tests) — include_3xx_compat=True passes 3xx through
+- `TestOnly3xxResultsDefaultFilter` (3 tests) — all-3xx results produce empty filtered output
+- `TestErrorRowsAlwaysIncluded` (4 tests) — ERROR:* rows bypass filter
+- `TestSubjectCountMatchesRowCount` (4 tests) — subject count equals rendered row count
+- `TestAll200Results` (4 tests) — all-200 scan filtered out; excluded_summary populated
+- `TestIs3xx` (16 tests) — unchanged boundary tests for `emailer._is_3xx()`
+- `TestArgumentParserInclude3xxFlag` (6 tests) — deprecated flag parsing + help text
+- `TestBuildFilterDeprecation` (7 tests) — deprecation warning, backward compat, new flag wins
+
+### Updated: `tests/test_emailer.py`
+- `TestBuildEmailHtml` (8 tests) — updated `_build` helper to accept `excluded_summary`
+- `TestSendEmailNotification` (8 tests) — updated `_call_with_env` for new signature; updated subject assertions
+
+### Updated: `tests/test_reporter.py`
+- Renamed 2 tests to document new "write all received rows" contract
+
+### Updated: `tests/test_argument_parser.py`
+- Added 5 tests for `--keep-status-codes` parameter
+
+### Updated: `tests/test_integration.py`
+- Updated `test_contains_200_status` → `test_200_status_excluded_by_default_filter`
+- Added `TestIntegrationNoFilter` class with `--keep-status-codes ""` verifying 200 appears
+
+### Bug found and fixed during testing
+`checker._build_filter` used `args.keep_status_codes or "404,500"` which coerces an explicit `""` to the default. Fixed to `args.keep_status_codes if args.keep_status_codes is not None else "404,500"`.
+
+## Results
+
+```
+Ran 175 tests in 8.059s
+
+OK
+```
+
+All 175 tests passed. No failures, no errors.
+
+### Test Summary
+
+175 tests run across 10 test files. All passed. The new `--keep-status-codes` parameter, the `StatusFilter` domain type, the excluded-codes email summary, and the deprecated flag backward-compat behavior are all covered.
+
+status: passed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Tool Paths (Windows bash shell)
+
+Tools are NOT on the default PATH and `export PATH=...` does not work in this shell. Always use full paths:
+
+- `python`: `/e/Applications/Scoop/apps/python/current/python.exe`
+- `git`: `/e/Applications/Scoop/apps/git/current/bin/git`
+- `gh`: `/e/Applications/Scoop/apps/gh/current/bin/gh`
+- `rtk`: `/e/rtk/bin/rtk`
+
 ## Commands
 
 No dependencies beyond the Python standard library. No install step needed.

--- a/src/argument_parser.py
+++ b/src/argument_parser.py
@@ -44,13 +44,23 @@ def build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--keep-status-codes",
+        default=None,
+        metavar="CODES",
+        help=(
+            "Comma-separated HTTP status codes to include in CSV and email output. "
+            "Default: 404,500. Pass an empty string to include all codes. "
+            "ERROR:* results are always included regardless of this setting."
+        ),
+    )
+    parser.add_argument(
         "--include-3xx-status-code",
         action="store_true",
         default=False,
         help=(
-            "Include 3xx redirect results in the email notification table. "
-            "By default, 3xx results are excluded from the email (but still appear in the CSV). "
-            "Has no effect when --notify-email is absent."
+            "[DEPRECATED] Use --keep-status-codes instead. "
+            "When supplied without --keep-status-codes, adds 3xx redirect codes to the "
+            "default filter (404,500). Has no effect when --keep-status-codes is also provided."
         ),
     )
     return parser

--- a/src/checker.py
+++ b/src/checker.py
@@ -24,7 +24,7 @@ def _build_filter(args) -> status_filter_module.StatusFilter:
         )
         if args.keep_status_codes is None:
             include_3xx_compat = True
-    codes_raw = args.keep_status_codes or "404,500"
+    codes_raw = args.keep_status_codes if args.keep_status_codes is not None else "404,500"
     return status_filter_module.build_filter(codes_raw, include_3xx_compat)
 
 

--- a/src/checker.py
+++ b/src/checker.py
@@ -12,23 +12,39 @@ import crawler
 import emailer
 import fetcher
 import reporter
+import status_filter as status_filter_module
+
+
+def _build_filter(args) -> status_filter_module.StatusFilter:
+    include_3xx_compat = False
+    if args.include_3xx_status_code:
+        print(
+            "Warning: --include-3xx-status-code is deprecated; use --keep-status-codes instead.",
+            file=sys.stderr,
+        )
+        if args.keep_status_codes is None:
+            include_3xx_compat = True
+    codes_raw = args.keep_status_codes or "404,500"
+    return status_filter_module.build_filter(codes_raw, include_3xx_compat)
 
 
 def _maybe_send_notification(
     args,
-    results: list[tuple[str, str, str]],
+    filtered_results: list,
+    excluded_summary: dict,
+    total_links: int,
     website: str,
     scan_timestamp: str,
 ) -> None:
     if args.notify_email is None:
         return
     emailer.send_email_notification(
-        results,
+        filtered_results,
+        excluded_summary,
         website,
         scan_timestamp,
-        len(results),
+        total_links,
         args.notify_email,
-        args.include_3xx_status_code,
     )
 
 
@@ -72,26 +88,28 @@ def main() -> None:
 
     results.sort(key=lambda row: (row[1], row[0]))
 
+    result_filter = _build_filter(args)
+    filtered = [r for r in results if result_filter.matches(r[2])]
+    excluded = result_filter.excluded_summary(results)
+
     if args.output is not None:
-        # Legacy mode: flat CSV only, no README.md
         csv_path = args.output
         md_path = None
     else:
-        # Scan-folder mode
         website = parsed.netloc.replace(":", "_")
         scan_dir = os.path.join("scans", website, scan_timestamp)
         os.makedirs(scan_dir, exist_ok=True)
         csv_path = os.path.join(scan_dir, "results.csv")
         md_path = os.path.join(scan_dir, "README.md")
 
-    reporter.write_csv(results, csv_path)
+    reporter.write_csv(filtered, csv_path)
 
     if md_path is not None:
-        reporter.write_markdown_summary(results, md_path, scan_timestamp)
+        reporter.write_markdown_summary(filtered, md_path, scan_timestamp)
 
     print(f"Checked {len(results)} links. Results written to {csv_path}.")
 
-    _maybe_send_notification(args, results, parsed.netloc, scan_timestamp)
+    _maybe_send_notification(args, filtered, excluded, len(results), parsed.netloc, scan_timestamp)
 
 
 if __name__ == "__main__":

--- a/src/emailer.py
+++ b/src/emailer.py
@@ -135,6 +135,6 @@ def send_email_notification(
         return
     resend.api_key = _RESEND_API_KEY
     filtered_count = len(filtered_results)
-    subject = "Dead link scan: {} — {} result(s) matching filter".format(website, filtered_count)
+    subject = "Dead link scan: {} - {} broken link(s) to review".format(website, filtered_count)
     body = _build_email_html(website, timestamp, total_links, filtered_results, excluded_summary)
     _send_via_resend(notify_email, _RESEND_FROM_ADDRESS, subject, body)

--- a/src/emailer.py
+++ b/src/emailer.py
@@ -10,9 +10,13 @@ _RESEND_API_KEY = os.environ.get("RESEND_API_KEY")
 _RESEND_FROM_ADDRESS = os.environ.get("RESEND_FROM_ADDRESS")
 
 
-def _build_email_rows(non_200_results: list[tuple[str, str, str]]) -> str:
+def _is_3xx(status: str) -> bool:
+    return len(status) == 3 and status.startswith("3") and status.isdigit()
+
+
+def _build_email_rows(results: list) -> str:
     rows = []
-    for link, referrer, status in non_200_results:
+    for link, referrer, status in results:
         rows.append(
             "<tr><td>{}</td><td>{}</td><td>{}</td></tr>".format(
                 html.escape(link),
@@ -23,26 +27,56 @@ def _build_email_rows(non_200_results: list[tuple[str, str, str]]) -> str:
     return "\n".join(rows)
 
 
+def _build_table_html(results: list) -> str:
+    return (
+        "<table>"
+        "<thead><tr><th>Link</th><th>Referrer</th><th>Status</th></tr></thead>"
+        "<tbody>{}</tbody>"
+        "</table>".format(_build_email_rows(results))
+    )
+
+
+def _format_excluded_item(code: str, count: int) -> str:
+    return "<li>{}: {}</li>".format(html.escape(code), count)
+
+
+def _build_excluded_summary_html(excluded_summary: dict) -> str:
+    if not excluded_summary:
+        return ""
+    items = "".join(
+        _format_excluded_item(code, count)
+        for code, count in sorted(excluded_summary.items())
+    )
+    return "<p>Excluded status codes (not in filter):</p><ul>{}</ul>".format(items)
+
+
+def _build_email_summary_lines(
+    website: str,
+    timestamp: str,
+    total_links: int,
+    filtered_count: int,
+) -> list:
+    return [
+        "<p>Website: <strong>{}</strong></p>".format(html.escape(website)),
+        "<p>Scan timestamp: {}</p>".format(html.escape(timestamp)),
+        "<p>Total links checked: {}</p>".format(total_links),
+        "<p>Results matching filter: {}</p>".format(filtered_count),
+    ]
+
+
 def _build_email_html(
     website: str,
     timestamp: str,
     total_links: int,
-    non_200_results: list[tuple[str, str, str]],
+    filtered_results: list,
+    excluded_summary: dict,
 ) -> str:
-    non_200_count = len(non_200_results)
-    lines = [
-        "<p>Website: <strong>{}</strong></p>".format(html.escape(website)),
-        "<p>Scan timestamp: {}</p>".format(html.escape(timestamp)),
-        "<p>Total links checked: {}</p>".format(total_links),
-        "<p>Non-200 results: {}</p>".format(non_200_count),
-    ]
-    if non_200_results:
-        lines.append(
-            "<table>"
-            "<thead><tr><th>Link</th><th>Referrer</th><th>Status</th></tr></thead>"
-            "<tbody>{}</tbody>"
-            "</table>".format(_build_email_rows(non_200_results))
-        )
+    lines = _build_email_summary_lines(website, timestamp, total_links, len(filtered_results))
+    excluded_html = _build_excluded_summary_html(excluded_summary)
+    if excluded_html:
+        lines.append(excluded_html)
+    if filtered_results:
+        lines.append(_build_table_html(filtered_results))
     return "\n".join(lines)
 
 
@@ -68,35 +102,30 @@ def _send_via_resend(
         )
 
 
-def _is_3xx(status: str) -> bool:
-    return len(status) == 3 and status.startswith("3") and status.isdigit()
-
-
 def send_email_notification(
-    results: list[tuple[str, str, str]],
+    filtered_results: list,
+    excluded_summary: dict,
     website: str,
     timestamp: str,
     total_links: int,
     notify_email: str,
-    include_3xx: bool = False,
 ) -> None:
     """Send an email notification with scan results via the Resend API.
 
     Parameters
     ----------
-    results:
-        Full list of (link, referrer, http_status_code) tuples.
+    filtered_results:
+        Pre-filtered list of (link, referrer, http_status_code) tuples to show in the table.
+    excluded_summary:
+        Mapping of status_code -> count for results excluded by the filter.
     website:
         The netloc of the scanned URL (used in subject and body).
     timestamp:
         The scan timestamp string (e.g. "2026-02-24T14-05-32").
     total_links:
-        Total number of links checked.
+        Total number of links checked (unfiltered count).
     notify_email:
         Recipient email address.
-    include_3xx:
-        When False (default), 3xx redirect results are excluded from the email
-        table and subject-line count. When True, they are included.
     """
     if _RESEND_API_KEY is None:
         print("Warning: RESEND_API_KEY is not set; notification skipped.", file=sys.stderr)
@@ -105,11 +134,7 @@ def send_email_notification(
         print("Warning: RESEND_FROM_ADDRESS is not set; notification skipped.", file=sys.stderr)
         return
     resend.api_key = _RESEND_API_KEY
-    non_200_results = [
-        row for row in results
-        if row[2] != "200" and (include_3xx or not _is_3xx(row[2]))
-    ]
-    non_200_count = len(non_200_results)
-    subject = "Dead link scan: {} — {} non-200 result(s)".format(website, non_200_count)
-    body = _build_email_html(website, timestamp, total_links, non_200_results)
+    filtered_count = len(filtered_results)
+    subject = "Dead link scan: {} — {} result(s) matching filter".format(website, filtered_count)
+    body = _build_email_html(website, timestamp, total_links, filtered_results, excluded_summary)
     _send_via_resend(notify_email, _RESEND_FROM_ADDRESS, subject, body)

--- a/src/reporter.py
+++ b/src/reporter.py
@@ -44,13 +44,12 @@ def write_markdown_summary(
 
     Prints an error to stderr and exits with code 1 if the file cannot be opened.
     """
-    non_200 = [row for row in results if row[2] != "200"]
     try:
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(f"## {timestamp}\n\n")
             f.write("| URL | Referrer | HTTP Status |\n")
             f.write("|---|---|---|\n")
-            for link, referrer, status in non_200:
+            for link, referrer, status in results:
                 f.write(f"| {link} | {referrer} | {status} |\n")
     except OSError as e:
         print(f"Error: cannot write to '{output_path}': {e}", file=sys.stderr)

--- a/src/status_filter.py
+++ b/src/status_filter.py
@@ -20,6 +20,7 @@ class StatusFilter:
             or (self._include_3xx_compat and _is_3xx(status))
         )
 
+    # Increment the running count for status codes that don't pass the filter.
     def _tally_excluded(self, summary: dict, status: str) -> None:
         if self.matches(status):
             return

--- a/src/status_filter.py
+++ b/src/status_filter.py
@@ -1,0 +1,39 @@
+"""Status code filter — controls which results appear in output."""
+
+
+def _is_3xx(status: str) -> bool:
+    return len(status) == 3 and status.startswith("3") and status.isdigit()
+
+
+class StatusFilter:
+    """Determines which HTTP status codes pass through to output."""
+
+    def __init__(self, codes: frozenset, include_3xx_compat: bool) -> None:
+        self._codes = codes
+        self._include_3xx_compat = include_3xx_compat
+
+    def matches(self, status: str) -> bool:
+        return (
+            status.startswith("ERROR:")
+            or not self._codes
+            or status in self._codes
+            or (self._include_3xx_compat and _is_3xx(status))
+        )
+
+    def _tally_excluded(self, summary: dict, status: str) -> None:
+        if self.matches(status):
+            return
+        summary[status] = summary.get(status, 0) + 1
+
+    def excluded_summary(self, results: list) -> dict:
+        summary: dict = {}
+        for _, _, status in results:
+            self._tally_excluded(summary, status)
+        return summary
+
+
+def build_filter(codes_raw: str, include_3xx_compat: bool = False) -> StatusFilter:
+    if not codes_raw:
+        return StatusFilter(frozenset(), include_3xx_compat)
+    codes = frozenset(c.strip() for c in codes_raw.split(",") if c.strip())
+    return StatusFilter(codes, include_3xx_compat)

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -117,6 +117,33 @@ class TestBuildArgParser(unittest.TestCase):
         args = self._parse(["https://example.com/", "--notify-email", "user@example.com"])
         self.assertEqual(args.notify_email, "user@example.com")
 
+    # --- --keep-status-codes ---
+
+    def test_keep_status_codes_default_is_none(self):
+        """--keep-status-codes defaults to None when omitted."""
+        args = self._parse(["https://example.com/"])
+        self.assertIsNone(args.keep_status_codes)
+
+    def test_keep_status_codes_stores_value(self):
+        """--keep-status-codes stores the provided string."""
+        args = self._parse(["https://example.com/", "--keep-status-codes", "404,500,403"])
+        self.assertEqual(args.keep_status_codes, "404,500,403")
+
+    def test_keep_status_codes_accepts_single_code(self):
+        """--keep-status-codes accepts a single status code."""
+        args = self._parse(["https://example.com/", "--keep-status-codes", "404"])
+        self.assertEqual(args.keep_status_codes, "404")
+
+    def test_keep_status_codes_accepts_empty_string(self):
+        """--keep-status-codes accepts an empty string (means no filter)."""
+        args = self._parse(["https://example.com/", "--keep-status-codes", ""])
+        self.assertEqual(args.keep_status_codes, "")
+
+    def test_keep_status_codes_is_string(self):
+        """--keep-status-codes stores value as a string."""
+        args = self._parse(["https://example.com/", "--keep-status-codes", "404,500"])
+        self.assertIsInstance(args.keep_status_codes, str)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -307,7 +307,7 @@ class TestSendEmailNotification(unittest.TestCase):
         subject = captured.get("subject", "")
         self.assertIn("example.com", subject)
         self.assertIn("1", subject)
-        self.assertIn("result(s) matching filter", subject)
+        self.assertIn("broken link(s) to review", subject)
 
     # --- delegates to _send_via_resend ---
 
@@ -359,7 +359,7 @@ class TestSendEmailNotification(unittest.TestCase):
     # --- all-200 results ---
 
     def test_empty_filtered_results_sends_email_with_zero_count(self):
-        """When filtered_results is empty, subject shows 0 result(s) matching filter."""
+        """When filtered_results is empty, subject shows 0 broken link(s) to review."""
         captured = {}
 
         def fake_send(notify_email, from_address, subject, body):
@@ -379,7 +379,7 @@ class TestSendEmailNotification(unittest.TestCase):
 
         subject = captured.get("subject", "")
         self.assertIn("0", subject)
-        self.assertIn("result(s) matching filter", subject)
+        self.assertIn("broken link(s) to review", subject)
 
 
 if __name__ == "__main__":

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -67,10 +67,12 @@ class TestBuildEmailHtml(unittest.TestCase):
     """Tests for emailer._build_email_html()."""
 
     def _build(self, website="example.com", timestamp="2026-02-24T14-05-32",
-               total_links=10, non_200_results=None):
+               total_links=10, non_200_results=None, excluded_summary=None):
         if non_200_results is None:
             non_200_results = []
-        return emailer._build_email_html(website, timestamp, total_links, non_200_results)
+        if excluded_summary is None:
+            excluded_summary = {}
+        return emailer._build_email_html(website, timestamp, total_links, non_200_results, excluded_summary)
 
     def test_contains_website(self):
         """Output contains the website name."""
@@ -205,17 +207,20 @@ class TestSendEmailNotification(unittest.TestCase):
         ("https://example.com/gone", "https://example.com/", "404"),
     ]
 
-    def _call_with_env(self, api_key, from_address, results=None, notify_email="user@example.com"):
+    def _call_with_env(self, api_key, from_address, filtered_results=None, excluded_summary=None, notify_email="user@example.com"):
         """Patch module-level env-var constants and call send_email_notification."""
-        if results is None:
-            results = self._RESULTS
+        if filtered_results is None:
+            filtered_results = [r for r in self._RESULTS if r[2] != "200"]
+        if excluded_summary is None:
+            excluded_summary = {}
         with patch.object(emailer, "_RESEND_API_KEY", api_key), \
              patch.object(emailer, "_RESEND_FROM_ADDRESS", from_address):
             emailer.send_email_notification(
-                results=results,
+                filtered_results=filtered_results,
+                excluded_summary=excluded_summary,
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
-                total_links=len(results),
+                total_links=len(self._RESULTS),
                 notify_email=notify_email,
             )
 
@@ -251,53 +256,58 @@ class TestSendEmailNotification(unittest.TestCase):
 
     # --- filters non-200 results ---
 
-    def test_only_non_200_results_included_in_email(self):
-        """Only non-200 rows are passed to _build_email_html."""
+    def test_filtered_results_passed_to_build_email_html(self):
+        """The filtered_results list is passed verbatim to _build_email_html."""
         captured = {}
 
-        def fake_build_html(website, timestamp, total_links, non_200_results):
-            captured["non_200_results"] = non_200_results
+        def fake_build_html(website, timestamp, total_links, filtered_results, excluded_summary):
+            captured["filtered_results"] = filtered_results
             return "<p>body</p>"
 
+        filtered = [r for r in self._RESULTS if r[2] != "200"]
         with patch.object(emailer, "_RESEND_API_KEY", "key"), \
              patch.object(emailer, "_RESEND_FROM_ADDRESS", "from@example.com"), \
              patch("emailer._build_email_html", side_effect=fake_build_html), \
              patch("emailer._send_via_resend"):
             emailer.send_email_notification(
-                results=self._RESULTS,
+                filtered_results=filtered,
+                excluded_summary={},
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
-                total_links=2,
+                total_links=len(self._RESULTS),
                 notify_email="user@example.com",
             )
 
-        non_200 = captured["non_200_results"]
-        self.assertEqual(len(non_200), 1)
-        self.assertEqual(non_200[0][2], "404")
+        rows = captured["filtered_results"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][2], "404")
 
     # --- subject line ---
 
     def test_subject_contains_website_and_count(self):
-        """Email subject contains the website and non-200 count."""
+        """Email subject contains the website and filtered result count."""
         captured = {}
 
         def fake_send(notify_email, from_address, subject, body):
             captured["subject"] = subject
 
+        filtered = [r for r in self._RESULTS if r[2] != "200"]
         with patch.object(emailer, "_RESEND_API_KEY", "key"), \
              patch.object(emailer, "_RESEND_FROM_ADDRESS", "from@example.com"), \
              patch("emailer._send_via_resend", side_effect=fake_send):
             emailer.send_email_notification(
-                results=self._RESULTS,
+                filtered_results=filtered,
+                excluded_summary={},
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
-                total_links=2,
+                total_links=len(self._RESULTS),
                 notify_email="user@example.com",
             )
 
         subject = captured.get("subject", "")
         self.assertIn("example.com", subject)
-        self.assertIn("1", subject)  # 1 non-200 result
+        self.assertIn("1", subject)
+        self.assertIn("result(s) matching filter", subject)
 
     # --- delegates to _send_via_resend ---
 
@@ -313,7 +323,8 @@ class TestSendEmailNotification(unittest.TestCase):
              patch.object(emailer, "_RESEND_FROM_ADDRESS", "real-from@example.com"), \
              patch("emailer._send_via_resend", side_effect=fake_send):
             emailer.send_email_notification(
-                results=[],
+                filtered_results=[],
+                excluded_summary={},
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
                 total_links=0,
@@ -335,7 +346,8 @@ class TestSendEmailNotification(unittest.TestCase):
              patch.object(emailer, "_RESEND_FROM_ADDRESS", "from@example.com"), \
              patch("emailer._send_via_resend", side_effect=fake_send):
             emailer.send_email_notification(
-                results=[],
+                filtered_results=[],
+                excluded_summary={},
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
                 total_links=0,
@@ -346,29 +358,28 @@ class TestSendEmailNotification(unittest.TestCase):
 
     # --- all-200 results ---
 
-    def test_all_200_results_sends_email_with_zero_non_200_count(self):
-        """When all results are 200, the email is still sent with 0 non-200 count in subject."""
+    def test_empty_filtered_results_sends_email_with_zero_count(self):
+        """When filtered_results is empty, subject shows 0 result(s) matching filter."""
         captured = {}
 
         def fake_send(notify_email, from_address, subject, body):
             captured["subject"] = subject
 
-        all_200 = [
-            ("https://example.com/", "", "200"),
-            ("https://example.com/about", "https://example.com/", "200"),
-        ]
         with patch.object(emailer, "_RESEND_API_KEY", "key"), \
              patch.object(emailer, "_RESEND_FROM_ADDRESS", "from@example.com"), \
              patch("emailer._send_via_resend", side_effect=fake_send):
             emailer.send_email_notification(
-                results=all_200,
+                filtered_results=[],
+                excluded_summary={"200": 2},
                 website="example.com",
                 timestamp="2026-02-24T14-05-32",
                 total_links=2,
                 notify_email="user@example.com",
             )
 
-        self.assertIn("0", captured.get("subject", ""))
+        subject = captured.get("subject", "")
+        self.assertIn("0", subject)
+        self.assertIn("result(s) matching filter", subject)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,10 +81,10 @@ class TestIntegration(unittest.TestCase):
         statuses = [row["http_status_code"] for row in self.csv_rows]
         self.assertIn("404", statuses, msg=f"No 404 found. Rows: {self.csv_rows}")
 
-    def test_contains_200_status(self):
-        """At least one row has http_status_code of 200."""
+    def test_200_status_excluded_by_default_filter(self):
+        """200 rows are excluded from CSV by the default filter (404,500)."""
         statuses = [row["http_status_code"] for row in self.csv_rows]
-        self.assertIn("200", statuses, msg=f"No 200 found. Rows: {self.csv_rows}")
+        self.assertNotIn("200", statuses, msg=f"Unexpected 200 in filtered output. Rows: {self.csv_rows}")
 
     def test_about_page_is_404(self):
         """The /about/ page appears in results with status 404."""
@@ -97,6 +97,52 @@ class TestIntegration(unittest.TestCase):
             len(matching) >= 1,
             msg=f"Expected {about_url!r} with status 404. Rows: {self.csv_rows}",
         )
+
+
+class TestIntegrationNoFilter(unittest.TestCase):
+    """Live integration test with --keep-status-codes '' (no filter) to verify 200 rows appear."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_output = tempfile.NamedTemporaryFile(
+            suffix=".csv", delete=False
+        ).name
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                CHECKER_PATH,
+                SAMPLE_SITE,
+                "--output", cls.tmp_output,
+                "--workers", "5",
+                "--timeout", "15",
+                "--keep-status-codes", "",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        cls.exit_code = result.returncode
+
+        cls.csv_rows = []
+        if os.path.exists(cls.tmp_output):
+            with open(cls.tmp_output, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                cls.csv_rows = list(reader)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.tmp_output):
+            os.unlink(cls.tmp_output)
+
+    def test_exit_code_is_zero(self):
+        """The checker exits with code 0 when --keep-status-codes is empty."""
+        self.assertEqual(self.exit_code, 0)
+
+    def test_contains_200_status_when_no_filter(self):
+        """200 rows appear in CSV when --keep-status-codes '' disables filtering."""
+        statuses = [row["http_status_code"] for row in self.csv_rows]
+        self.assertIn("200", statuses, msg=f"No 200 found. Rows: {self.csv_rows}")
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_35_include_3xx.py
+++ b/tests/test_issue_35_include_3xx.py
@@ -1,16 +1,18 @@
-"""Tests for issue #35 — --include-3xx-status-code flag.
+"""Tests for --include-3xx-status-code deprecation and --keep-status-codes filter.
 
 Covers:
-1. Default (flag absent): 3xx rows excluded from email, CSV unaffected.
-2. Flag present: 3xx rows included in email.
-3. Flag absent + only 3xx non-200 results: email table empty, count = 0.
-4. ERROR:* strings always appear regardless of flag.
-5. Subject-line count matches rendered row count in both flag states.
-6. All-200 scan: email table empty regardless of flag.
+1. Default filter (404,500): 3xx rows excluded from output.
+2. include_3xx_compat=True: 3xx rows included in output.
+3. Only 3xx non-200 results with default filter: table empty, count = 0.
+4. ERROR:* strings always appear regardless of filter.
+5. Subject-line count matches rendered row count.
+6. All-200 scan: table empty when filter is 404,500.
 7. _is_3xx helper boundary conditions.
 8. argument_parser: --include-3xx-status-code flag defaults and stores correctly.
+9. checker._build_filter: deprecation warning and backward-compat logic.
 """
 
+import io
 import os
 import sys
 import unittest
@@ -23,6 +25,7 @@ if SRC_DIR not in sys.path:
 
 import emailer
 import argument_parser
+import status_filter as sf
 
 
 # ---------------------------------------------------------------------------
@@ -44,12 +47,17 @@ _MIXED_RESULTS = [
 ]
 
 
-def _call_send(results, include_3xx=False):
-    """Call send_email_notification with mocked env-vars; return captured subject and non_200_results."""
+def _call_send(results, include_3xx_compat=False, filter_codes="404,500"):
+    """Build a StatusFilter, apply it to results, call send_email_notification."""
+    filter_obj = sf.build_filter(filter_codes, include_3xx_compat)
+    filtered = [r for r in results if filter_obj.matches(r[2])]
+    excluded = filter_obj.excluded_summary(results)
+
     captured = {}
 
-    def fake_build_html(website, timestamp, total_links, non_200_results):
-        captured["non_200_results"] = non_200_results
+    def fake_build_html(website, timestamp, total_links, filtered_results, excluded_summary):
+        captured["non_200_results"] = filtered_results
+        captured["excluded_summary"] = excluded_summary
         return "<p>body</p>"
 
     def fake_send_via_resend(notify_email, from_address, subject, body):
@@ -60,70 +68,75 @@ def _call_send(results, include_3xx=False):
          patch("emailer._build_email_html", side_effect=fake_build_html), \
          patch("emailer._send_via_resend", side_effect=fake_send_via_resend):
         emailer.send_email_notification(
-            results=results,
+            filtered_results=filtered,
+            excluded_summary=excluded,
             website="example.com",
             timestamp="2026-02-26T13-00-00",
             total_links=len(results),
             notify_email="user@example.com",
-            include_3xx=include_3xx,
         )
     return captured
 
 
 # ---------------------------------------------------------------------------
-# Test Case 1: Default behaviour (flag absent) — 3xx excluded from email
+# Test Case 1: Default filter (404,500) — 3xx excluded
 # ---------------------------------------------------------------------------
 
-class TestDefaultExcludes3xx(unittest.TestCase):
-    """With include_3xx=False (default) 3xx rows must not appear in email."""
+class TestDefaultFilterExcludes3xx(unittest.TestCase):
+    """With default filter (404,500) 3xx rows must not appear in output."""
 
     def setUp(self):
-        self.captured = _call_send(_MIXED_RESULTS, include_3xx=False)
+        self.captured = _call_send(_MIXED_RESULTS, include_3xx_compat=False)
         self.non_200 = self.captured["non_200_results"]
 
-    def test_3xx_rows_absent_from_non_200_results(self):
-        """301 and 302 rows must not be in non_200_results when flag is absent."""
+    def test_3xx_rows_absent_from_filtered_results(self):
+        """301 and 302 rows must not be in filtered results with default filter."""
         statuses = [row[2] for row in self.non_200]
         self.assertNotIn("301", statuses)
         self.assertNotIn("302", statuses)
 
     def test_404_and_500_rows_present(self):
-        """404 and 500 rows must still appear in non_200_results."""
+        """404 and 500 rows must appear in filtered results."""
         statuses = [row[2] for row in self.non_200]
         self.assertIn("404", statuses)
         self.assertIn("500", statuses)
 
     def test_200_row_absent(self):
-        """200 row is never included in non_200_results."""
+        """200 row is not in filtered results (not in default filter 404,500)."""
         statuses = [row[2] for row in self.non_200]
         self.assertNotIn("200", statuses)
 
     def test_subject_count_excludes_3xx(self):
-        """Subject-line count equals the number of non-3xx, non-200 rows (including errors)."""
-        # 404, 500, ERROR:ConnectionError = 3 rows
+        """Subject count equals the number of matching rows (404, 500, ERROR = 3)."""
         subject = self.captured["subject"]
-        self.assertIn("3 non-200 result(s)", subject)
+        self.assertIn("3 result(s) matching filter", subject)
 
     def test_subject_count_matches_row_count(self):
         """Subject count matches len(non_200_results)."""
         subject = self.captured["subject"]
         expected = str(len(self.non_200))
-        self.assertIn(expected + " non-200 result(s)", subject)
+        self.assertIn(expected + " result(s) matching filter", subject)
+
+    def test_3xx_rows_appear_in_excluded_summary(self):
+        """301 and 302 are counted in excluded_summary."""
+        excluded = self.captured["excluded_summary"]
+        self.assertIn("301", excluded)
+        self.assertIn("302", excluded)
 
 
 # ---------------------------------------------------------------------------
-# Test Case 2: Flag present — 3xx included in email
+# Test Case 2: include_3xx_compat=True — 3xx included
 # ---------------------------------------------------------------------------
 
-class TestFlagPresentIncludes3xx(unittest.TestCase):
-    """With include_3xx=True all non-200 rows (including 3xx) must appear."""
+class TestInclude3xxCompatIncludes3xx(unittest.TestCase):
+    """With include_3xx_compat=True all 3xx codes appear alongside 404/500."""
 
     def setUp(self):
-        self.captured = _call_send(_MIXED_RESULTS, include_3xx=True)
+        self.captured = _call_send(_MIXED_RESULTS, include_3xx_compat=True)
         self.non_200 = self.captured["non_200_results"]
 
-    def test_3xx_rows_present_in_non_200_results(self):
-        """301 and 302 rows must be in non_200_results when flag is present."""
+    def test_3xx_rows_present_in_filtered_results(self):
+        """301 and 302 rows must be in filtered results when 3xx compat is active."""
         statuses = [row[2] for row in self.non_200]
         self.assertIn("301", statuses)
         self.assertIn("302", statuses)
@@ -136,28 +149,28 @@ class TestFlagPresentIncludes3xx(unittest.TestCase):
         self.assertIn("ERROR:ConnectionError", statuses)
 
     def test_200_row_still_absent(self):
-        """200 row is never in non_200_results even when flag is present."""
+        """200 row is never in filtered results even with 3xx compat."""
         statuses = [row[2] for row in self.non_200]
         self.assertNotIn("200", statuses)
 
     def test_subject_count_includes_3xx(self):
-        """Subject-line count is 5 (301, 302, 404, 500, ERROR) when flag present."""
+        """Subject count is 5 (301, 302, 404, 500, ERROR) with 3xx compat."""
         subject = self.captured["subject"]
-        self.assertIn("5 non-200 result(s)", subject)
+        self.assertIn("5 result(s) matching filter", subject)
 
     def test_subject_count_matches_row_count(self):
         """Subject count matches len(non_200_results)."""
         subject = self.captured["subject"]
         expected = str(len(self.non_200))
-        self.assertIn(expected + " non-200 result(s)", subject)
+        self.assertIn(expected + " result(s) matching filter", subject)
 
 
 # ---------------------------------------------------------------------------
-# Test Case 3: Flag absent + only 3xx non-200 results => email table empty
+# Test Case 3: Default filter + only 3xx => table empty, count = 0
 # ---------------------------------------------------------------------------
 
-class TestOnly3xxResultsFlagAbsent(unittest.TestCase):
-    """When all non-200 results are 3xx and flag is absent, table is empty, count = 0."""
+class TestOnly3xxResultsDefaultFilter(unittest.TestCase):
+    """When all non-200 results are 3xx and default filter (404,500) is active, table empty."""
 
     _ONLY_3XX = [
         ("https://example.com/", "", "200"),
@@ -167,31 +180,32 @@ class TestOnly3xxResultsFlagAbsent(unittest.TestCase):
     ]
 
     def setUp(self):
-        self.captured = _call_send(self._ONLY_3XX, include_3xx=False)
+        self.captured = _call_send(self._ONLY_3XX, include_3xx_compat=False)
         self.non_200 = self.captured["non_200_results"]
 
-    def test_non_200_results_is_empty(self):
-        """non_200_results list is empty when only 3xx statuses exist and flag absent."""
+    def test_filtered_results_is_empty(self):
+        """filtered_results is empty when only 3xx statuses exist and default filter used."""
         self.assertEqual(self.non_200, [])
 
     def test_subject_count_is_zero(self):
-        """Subject-line count is 0 when only 3xx results exist and flag absent."""
+        """Subject count is 0."""
         subject = self.captured["subject"]
-        self.assertIn("0 non-200 result(s)", subject)
+        self.assertIn("0 result(s) matching filter", subject)
 
-    def test_subject_count_matches_row_count(self):
-        """Subject count matches len(non_200_results) = 0."""
-        subject = self.captured["subject"]
-        self.assertIn("0 non-200 result(s)", subject)
-        self.assertEqual(len(self.non_200), 0)
+    def test_3xx_appear_in_excluded_summary(self):
+        """3xx codes appear in excluded_summary with correct counts."""
+        excluded = self.captured["excluded_summary"]
+        self.assertIn("301", excluded)
+        self.assertIn("302", excluded)
+        self.assertIn("307", excluded)
 
 
 # ---------------------------------------------------------------------------
-# Test Case 4: ERROR:* strings always appear regardless of flag
+# Test Case 4: ERROR:* strings always appear regardless of filter
 # ---------------------------------------------------------------------------
 
 class TestErrorRowsAlwaysIncluded(unittest.TestCase):
-    """ERROR:* statuses must appear in email regardless of include_3xx flag."""
+    """ERROR:* statuses must appear in filtered results regardless of filter."""
 
     _ERROR_RESULTS = [
         ("https://example.com/", "", "200"),
@@ -200,89 +214,87 @@ class TestErrorRowsAlwaysIncluded(unittest.TestCase):
         ("https://example.com/c", "https://example.com/", "ERROR:Timeout"),
     ]
 
-    def test_error_rows_present_flag_absent(self):
-        """ERROR:* rows present in non_200_results when include_3xx=False."""
-        captured = _call_send(self._ERROR_RESULTS, include_3xx=False)
+    def test_error_rows_present_with_default_filter(self):
+        """ERROR:* rows present with default filter (404,500)."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx_compat=False)
         statuses = [row[2] for row in captured["non_200_results"]]
         self.assertIn("ERROR:ConnectionError", statuses)
         self.assertIn("ERROR:Timeout", statuses)
 
-    def test_error_rows_present_flag_present(self):
-        """ERROR:* rows present in non_200_results when include_3xx=True."""
-        captured = _call_send(self._ERROR_RESULTS, include_3xx=True)
+    def test_error_rows_present_with_3xx_compat(self):
+        """ERROR:* rows present with 3xx compat active."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx_compat=True)
         statuses = [row[2] for row in captured["non_200_results"]]
         self.assertIn("ERROR:ConnectionError", statuses)
         self.assertIn("ERROR:Timeout", statuses)
 
-    def test_3xx_excluded_but_errors_included_flag_absent(self):
-        """301 excluded but ERROR rows remain when flag absent."""
-        captured = _call_send(self._ERROR_RESULTS, include_3xx=False)
+    def test_3xx_excluded_but_errors_included_default_filter(self):
+        """301 excluded but ERROR rows remain with default filter."""
+        captured = _call_send(self._ERROR_RESULTS, include_3xx_compat=False)
         statuses = [row[2] for row in captured["non_200_results"]]
         self.assertNotIn("301", statuses)
         self.assertIn("ERROR:ConnectionError", statuses)
 
-    def test_only_error_results_flag_absent(self):
-        """When only ERROR rows and 200 exist with flag absent, count equals error count."""
+    def test_only_error_results_with_default_filter(self):
+        """When only ERROR rows and 200 exist, count equals error count."""
         results = [
             ("https://example.com/", "", "200"),
             ("https://example.com/a", "https://example.com/", "ERROR:ConnectionError"),
         ]
-        captured = _call_send(results, include_3xx=False)
+        captured = _call_send(results, include_3xx_compat=False)
         self.assertEqual(len(captured["non_200_results"]), 1)
-        self.assertIn("1 non-200 result(s)", captured["subject"])
+        self.assertIn("1 result(s) matching filter", captured["subject"])
 
 
 # ---------------------------------------------------------------------------
-# Test Case 5: Subject-line count matches rendered row count (both states)
+# Test Case 5: Subject count matches rendered row count
 # ---------------------------------------------------------------------------
 
 class TestSubjectCountMatchesRowCount(unittest.TestCase):
-    """Subject-line count must always equal the number of rows that will be rendered."""
+    """Subject count must always equal the number of rows rendered."""
 
-    def _subject_count_matches(self, results, include_3xx):
-        captured = _call_send(results, include_3xx=include_3xx)
+    def _subject_count_matches(self, results, include_3xx_compat):
+        captured = _call_send(results, include_3xx_compat=include_3xx_compat)
         expected_count = len(captured["non_200_results"])
-        expected_str = "{} non-200 result(s)".format(expected_count)
+        expected_str = "{} result(s) matching filter".format(expected_count)
         self.assertIn(expected_str, captured["subject"])
         return expected_count
 
-    def test_flag_absent_mixed_results(self):
-        """Count in subject matches non_200_results length with flag absent."""
-        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx=False)
-        # 404 + 500 + ERROR = 3
+    def test_default_filter_mixed_results(self):
+        """Count in subject matches filtered count: 404 + 500 + ERROR = 3."""
+        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx_compat=False)
         self.assertEqual(count, 3)
 
-    def test_flag_present_mixed_results(self):
-        """Count in subject matches non_200_results length with flag present."""
-        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx=True)
-        # 301 + 302 + 404 + 500 + ERROR = 5
+    def test_3xx_compat_mixed_results(self):
+        """Count in subject matches filtered count: 301 + 302 + 404 + 500 + ERROR = 5."""
+        count = self._subject_count_matches(_MIXED_RESULTS, include_3xx_compat=True)
         self.assertEqual(count, 5)
 
-    def test_flag_absent_all_3xx(self):
-        """Count is 0 and matches subject when all non-200s are 3xx, flag absent."""
+    def test_default_filter_all_3xx(self):
+        """Count is 0 when all non-200s are 3xx and default filter used."""
         results = [
             ("https://example.com/", "", "200"),
             ("https://example.com/r", "https://example.com/", "301"),
         ]
-        count = self._subject_count_matches(results, include_3xx=False)
+        count = self._subject_count_matches(results, include_3xx_compat=False)
         self.assertEqual(count, 0)
 
-    def test_flag_present_one_3xx(self):
-        """Count is 1 when one 3xx result, flag present."""
+    def test_3xx_compat_one_3xx(self):
+        """Count is 1 when one 3xx result and 3xx compat active."""
         results = [
             ("https://example.com/", "", "200"),
             ("https://example.com/r", "https://example.com/", "301"),
         ]
-        count = self._subject_count_matches(results, include_3xx=True)
+        count = self._subject_count_matches(results, include_3xx_compat=True)
         self.assertEqual(count, 1)
 
 
 # ---------------------------------------------------------------------------
-# Test Case 6: All-200 scan — email table empty regardless of flag
+# Test Case 6: All-200 scan — table empty with default filter
 # ---------------------------------------------------------------------------
 
 class TestAll200Results(unittest.TestCase):
-    """When every link returns 200, non_200_results is empty under both flag states."""
+    """When every link returns 200, filtered results is empty under default filter."""
 
     _ALL_200 = [
         ("https://example.com/", "", "200"),
@@ -290,25 +302,27 @@ class TestAll200Results(unittest.TestCase):
         ("https://example.com/contact", "https://example.com/", "200"),
     ]
 
-    def test_empty_table_flag_absent(self):
-        """non_200_results is empty with all-200 scan and flag absent."""
-        captured = _call_send(self._ALL_200, include_3xx=False)
+    def test_empty_table_default_filter(self):
+        """filtered_results is empty with all-200 scan and default filter."""
+        captured = _call_send(self._ALL_200, include_3xx_compat=False)
         self.assertEqual(captured["non_200_results"], [])
 
-    def test_empty_table_flag_present(self):
-        """non_200_results is empty with all-200 scan and flag present."""
-        captured = _call_send(self._ALL_200, include_3xx=True)
+    def test_empty_table_3xx_compat(self):
+        """filtered_results is empty with all-200 scan and 3xx compat (200 not in filter)."""
+        captured = _call_send(self._ALL_200, include_3xx_compat=True)
         self.assertEqual(captured["non_200_results"], [])
 
-    def test_subject_count_zero_flag_absent(self):
-        """Subject shows 0 non-200 result(s) with all-200 scan, flag absent."""
-        captured = _call_send(self._ALL_200, include_3xx=False)
-        self.assertIn("0 non-200 result(s)", captured["subject"])
+    def test_subject_count_zero_default_filter(self):
+        """Subject shows 0 result(s) matching filter with all-200 scan."""
+        captured = _call_send(self._ALL_200, include_3xx_compat=False)
+        self.assertIn("0 result(s) matching filter", captured["subject"])
 
-    def test_subject_count_zero_flag_present(self):
-        """Subject shows 0 non-200 result(s) with all-200 scan, flag present."""
-        captured = _call_send(self._ALL_200, include_3xx=True)
-        self.assertIn("0 non-200 result(s)", captured["subject"])
+    def test_all_200_appear_in_excluded_summary(self):
+        """200 codes appear in excluded_summary."""
+        captured = _call_send(self._ALL_200, include_3xx_compat=False)
+        excluded = captured["excluded_summary"]
+        self.assertIn("200", excluded)
+        self.assertEqual(excluded["200"], 3)
 
 
 # ---------------------------------------------------------------------------
@@ -361,7 +375,6 @@ class TestIs3xx(unittest.TestCase):
         self.assertFalse(emailer._is_3xx("3000"))
 
     def test_non_digit_3xx_like_is_not_3xx(self):
-        """'3xx' is not a valid 3-char all-digit string starting with 3."""
         self.assertFalse(emailer._is_3xx("3xx"))
 
     def test_empty_string_is_not_3xx(self):
@@ -373,7 +386,7 @@ class TestIs3xx(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestArgumentParserInclude3xxFlag(unittest.TestCase):
-    """Tests for the --include-3xx-status-code CLI flag in argument_parser."""
+    """Tests for the deprecated --include-3xx-status-code CLI flag."""
 
     def _parse(self, argv):
         return argument_parser.build_arg_parser().parse_args(argv)
@@ -412,6 +425,94 @@ class TestArgumentParserInclude3xxFlag(unittest.TestCase):
         args = self._parse(["https://example.com/"])
         self.assertFalse(args.include_3xx_status_code)
         self.assertIsNone(args.notify_email)
+
+    def test_deprecated_help_text_contains_deprecated_marker(self):
+        """Help text for --include-3xx-status-code mentions DEPRECATED."""
+        import io as _io
+        buf = _io.StringIO()
+        try:
+            argument_parser.build_arg_parser().parse_args(["--help"])
+        except SystemExit:
+            pass
+        # Check the help action output via format_help
+        help_text = argument_parser.build_arg_parser().format_help()
+        self.assertIn("DEPRECATED", help_text)
+
+
+# ---------------------------------------------------------------------------
+# Test Case 9: checker._build_filter deprecation warning and backward compat
+# ---------------------------------------------------------------------------
+
+class TestBuildFilterDeprecation(unittest.TestCase):
+    """Tests for checker._build_filter() deprecation warning and flag interaction."""
+
+    def _make_args(self, keep_status_codes=None, include_3xx_status_code=False):
+        import types
+        args = types.SimpleNamespace()
+        args.keep_status_codes = keep_status_codes
+        args.include_3xx_status_code = include_3xx_status_code
+        return args
+
+    def test_deprecated_flag_emits_warning_to_stderr(self):
+        """When --include-3xx-status-code is set, a deprecation warning is printed to stderr."""
+        import checker
+        buf = io.StringIO()
+        args = self._make_args(include_3xx_status_code=True)
+        with patch("sys.stderr", buf):
+            checker._build_filter(args)
+        self.assertIn("deprecated", buf.getvalue())
+        self.assertIn("--keep-status-codes", buf.getvalue())
+
+    def test_no_warning_when_deprecated_flag_absent(self):
+        """No deprecation warning when --include-3xx-status-code is not set."""
+        import checker
+        buf = io.StringIO()
+        args = self._make_args(include_3xx_status_code=False)
+        with patch("sys.stderr", buf):
+            checker._build_filter(args)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_deprecated_flag_alone_includes_3xx_in_filter(self):
+        """When old flag is used without --keep-status-codes, 3xx codes pass through filter."""
+        import checker
+        args = self._make_args(include_3xx_status_code=True, keep_status_codes=None)
+        with patch("sys.stderr"):
+            filter_obj = checker._build_filter(args)
+        self.assertTrue(filter_obj.matches("301"))
+        self.assertTrue(filter_obj.matches("302"))
+        self.assertTrue(filter_obj.matches("404"))
+
+    def test_new_flag_wins_over_deprecated_when_both_provided(self):
+        """When both flags are provided, --keep-status-codes wins; 3xx are NOT auto-included."""
+        import checker
+        args = self._make_args(include_3xx_status_code=True, keep_status_codes="404")
+        with patch("sys.stderr"):
+            filter_obj = checker._build_filter(args)
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertFalse(filter_obj.matches("301"))
+
+    def test_default_filter_matches_404_and_500(self):
+        """Default filter (no flags) matches 404 and 500."""
+        import checker
+        args = self._make_args()
+        filter_obj = checker._build_filter(args)
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("500"))
+
+    def test_default_filter_excludes_200_and_3xx(self):
+        """Default filter excludes 200 and 3xx codes."""
+        import checker
+        args = self._make_args()
+        filter_obj = checker._build_filter(args)
+        self.assertFalse(filter_obj.matches("200"))
+        self.assertFalse(filter_obj.matches("301"))
+
+    def test_default_filter_passes_error_rows(self):
+        """Default filter always passes ERROR:* rows."""
+        import checker
+        args = self._make_args()
+        filter_obj = checker._build_filter(args)
+        self.assertTrue(filter_obj.matches("ERROR:URLError"))
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_35_include_3xx.py
+++ b/tests/test_issue_35_include_3xx.py
@@ -109,13 +109,13 @@ class TestDefaultFilterExcludes3xx(unittest.TestCase):
     def test_subject_count_excludes_3xx(self):
         """Subject count equals the number of matching rows (404, 500, ERROR = 3)."""
         subject = self.captured["subject"]
-        self.assertIn("3 result(s) matching filter", subject)
+        self.assertIn("3 broken link(s) to review", subject)
 
     def test_subject_count_matches_row_count(self):
         """Subject count matches len(non_200_results)."""
         subject = self.captured["subject"]
         expected = str(len(self.non_200))
-        self.assertIn(expected + " result(s) matching filter", subject)
+        self.assertIn(expected + " broken link(s) to review", subject)
 
     def test_3xx_rows_appear_in_excluded_summary(self):
         """301 and 302 are counted in excluded_summary."""
@@ -156,13 +156,13 @@ class TestInclude3xxCompatIncludes3xx(unittest.TestCase):
     def test_subject_count_includes_3xx(self):
         """Subject count is 5 (301, 302, 404, 500, ERROR) with 3xx compat."""
         subject = self.captured["subject"]
-        self.assertIn("5 result(s) matching filter", subject)
+        self.assertIn("5 broken link(s) to review", subject)
 
     def test_subject_count_matches_row_count(self):
         """Subject count matches len(non_200_results)."""
         subject = self.captured["subject"]
         expected = str(len(self.non_200))
-        self.assertIn(expected + " result(s) matching filter", subject)
+        self.assertIn(expected + " broken link(s) to review", subject)
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +190,7 @@ class TestOnly3xxResultsDefaultFilter(unittest.TestCase):
     def test_subject_count_is_zero(self):
         """Subject count is 0."""
         subject = self.captured["subject"]
-        self.assertIn("0 result(s) matching filter", subject)
+        self.assertIn("0 broken link(s) to review", subject)
 
     def test_3xx_appear_in_excluded_summary(self):
         """3xx codes appear in excluded_summary with correct counts."""
@@ -243,7 +243,7 @@ class TestErrorRowsAlwaysIncluded(unittest.TestCase):
         ]
         captured = _call_send(results, include_3xx_compat=False)
         self.assertEqual(len(captured["non_200_results"]), 1)
-        self.assertIn("1 result(s) matching filter", captured["subject"])
+        self.assertIn("1 broken link(s) to review", captured["subject"])
 
 
 # ---------------------------------------------------------------------------
@@ -256,7 +256,7 @@ class TestSubjectCountMatchesRowCount(unittest.TestCase):
     def _subject_count_matches(self, results, include_3xx_compat):
         captured = _call_send(results, include_3xx_compat=include_3xx_compat)
         expected_count = len(captured["non_200_results"])
-        expected_str = "{} result(s) matching filter".format(expected_count)
+        expected_str = "{} broken link(s) to review".format(expected_count)
         self.assertIn(expected_str, captured["subject"])
         return expected_count
 
@@ -313,9 +313,9 @@ class TestAll200Results(unittest.TestCase):
         self.assertEqual(captured["non_200_results"], [])
 
     def test_subject_count_zero_default_filter(self):
-        """Subject shows 0 result(s) matching filter with all-200 scan."""
+        """Subject shows 0 broken link(s) to review with all-200 scan."""
         captured = _call_send(self._ALL_200, include_3xx_compat=False)
-        self.assertIn("0 result(s) matching filter", captured["subject"])
+        self.assertIn("0 broken link(s) to review", captured["subject"])
 
     def test_all_200_appear_in_excluded_summary(self):
         """200 codes appear in excluded_summary."""

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -140,8 +140,8 @@ class TestWriteMarkdownSummary(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
-    def test_200_rows_do_not_appear_in_table_body(self):
-        """Rows with status 200 are excluded from the table body."""
+    def test_all_received_rows_appear_in_table_body(self):
+        """write_markdown_summary writes all received rows; filtering is the caller's responsibility."""
         results = [
             ("https://example.com/ok", "https://example.com/", "200"),
             ("https://example.com/gone", "https://example.com/", "404"),
@@ -153,20 +153,16 @@ class TestWriteMarkdownSummary(unittest.TestCase):
         try:
             reporter.write_markdown_summary(results, tmp_path, self.TIMESTAMP)
             with open(tmp_path, encoding="utf-8") as f:
-                lines = f.readlines()
-            # Data rows are lines containing '|' that come after the separator row
-            separator_idx = next(
-                i for i, ln in enumerate(lines) if ln.startswith("|---|")
-            )
-            data_lines = [ln for ln in lines[separator_idx + 1:] if ln.strip()]
-            # None of the data rows should reference the 200 URL
-            for ln in data_lines:
-                self.assertNotIn("https://example.com/ok", ln)
+                content = f.read()
+            self.assertIn("https://example.com/ok", content)
+            self.assertIn("200", content)
+            self.assertIn("https://example.com/gone", content)
+            self.assertIn("404", content)
         finally:
             os.unlink(tmp_path)
 
-    def test_all_200_results_produce_empty_table_body(self):
-        """When every result is 200, the table body contains no data rows."""
+    def test_all_received_rows_appear_when_only_200s_passed(self):
+        """write_markdown_summary writes every row it receives, including 200s."""
         results = [
             ("https://example.com/a", "https://example.com/", "200"),
             ("https://example.com/b", "https://example.com/", "200"),
@@ -179,16 +175,14 @@ class TestWriteMarkdownSummary(unittest.TestCase):
             reporter.write_markdown_summary(results, tmp_path, self.TIMESTAMP)
             with open(tmp_path, encoding="utf-8") as f:
                 lines = f.readlines()
-            # Header and separator must be present
             content = "".join(lines)
             self.assertIn("| URL | Referrer | HTTP Status |", content)
             self.assertIn("|---|---|---|", content)
-            # No data rows after the separator
             separator_idx = next(
                 i for i, ln in enumerate(lines) if ln.startswith("|---|")
             )
             data_lines = [ln for ln in lines[separator_idx + 1:] if ln.strip()]
-            self.assertEqual(data_lines, [])
+            self.assertEqual(len(data_lines), 2)
         finally:
             os.unlink(tmp_path)
 

--- a/tests/test_status_filter.py
+++ b/tests/test_status_filter.py
@@ -1,0 +1,220 @@
+"""Tests for status_filter.py."""
+
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC_DIR = os.path.join(PROJECT_ROOT, "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+import status_filter as sf
+
+
+# ---------------------------------------------------------------------------
+# _is_3xx
+# ---------------------------------------------------------------------------
+
+class TestIs3xx(unittest.TestCase):
+    """Unit tests for status_filter._is_3xx()."""
+
+    def test_300_through_399_are_3xx(self):
+        for code in ("300", "301", "302", "307", "308", "399"):
+            self.assertTrue(sf._is_3xx(code), f"{code} should be 3xx")
+
+    def test_200_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("200"))
+
+    def test_400_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("400"))
+
+    def test_error_string_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("ERROR:Timeout"))
+
+    def test_short_string_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("3"))
+
+    def test_long_string_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("3000"))
+
+    def test_empty_string_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx(""))
+
+    def test_non_digit_starting_with_3_is_not_3xx(self):
+        self.assertFalse(sf._is_3xx("3xx"))
+
+
+# ---------------------------------------------------------------------------
+# StatusFilter.matches
+# ---------------------------------------------------------------------------
+
+class TestStatusFilterMatches(unittest.TestCase):
+    """Tests for StatusFilter.matches()."""
+
+    def _filter(self, codes_raw, include_3xx_compat=False):
+        return sf.build_filter(codes_raw, include_3xx_compat)
+
+    def test_code_in_filter_matches(self):
+        """A status code in the filter set matches."""
+        filter_obj = self._filter("404,500")
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("500"))
+
+    def test_code_not_in_filter_does_not_match(self):
+        """A status code absent from the filter set does not match."""
+        filter_obj = self._filter("404,500")
+        self.assertFalse(filter_obj.matches("200"))
+        self.assertFalse(filter_obj.matches("301"))
+
+    def test_error_rows_always_match(self):
+        """ERROR:* rows always match regardless of filter."""
+        filter_obj = self._filter("404,500")
+        self.assertTrue(filter_obj.matches("ERROR:URLError"))
+        self.assertTrue(filter_obj.matches("ERROR:ConnectionError"))
+        self.assertTrue(filter_obj.matches("ERROR:Timeout"))
+
+    def test_empty_filter_matches_everything(self):
+        """An empty filter (no codes) matches every status."""
+        filter_obj = self._filter("")
+        self.assertTrue(filter_obj.matches("200"))
+        self.assertTrue(filter_obj.matches("301"))
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("ERROR:URLError"))
+
+    def test_include_3xx_compat_matches_3xx_codes(self):
+        """With include_3xx_compat=True, 3xx codes match even if not in the explicit set."""
+        filter_obj = self._filter("404,500", include_3xx_compat=True)
+        self.assertTrue(filter_obj.matches("301"))
+        self.assertTrue(filter_obj.matches("302"))
+        self.assertTrue(filter_obj.matches("307"))
+
+    def test_include_3xx_compat_still_excludes_200(self):
+        """With include_3xx_compat=True, 200 still does not match (not 3xx, not in set)."""
+        filter_obj = self._filter("404,500", include_3xx_compat=True)
+        self.assertFalse(filter_obj.matches("200"))
+
+    def test_whitespace_stripped_from_codes(self):
+        """build_filter strips whitespace around comma-separated codes."""
+        filter_obj = self._filter("404 , 500 , 403")
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("403"))
+
+    def test_single_code_filter(self):
+        """A filter with a single code only matches that code (and ERROR:*)."""
+        filter_obj = self._filter("404")
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertFalse(filter_obj.matches("500"))
+        self.assertTrue(filter_obj.matches("ERROR:URLError"))
+
+
+# ---------------------------------------------------------------------------
+# StatusFilter.excluded_summary
+# ---------------------------------------------------------------------------
+
+class TestStatusFilterExcludedSummary(unittest.TestCase):
+    """Tests for StatusFilter.excluded_summary()."""
+
+    _RESULTS = [
+        ("https://example.com/", "", "200"),
+        ("https://example.com/r", "https://example.com/", "301"),
+        ("https://example.com/g", "https://example.com/", "404"),
+        ("https://example.com/e", "https://example.com/", "500"),
+        ("https://example.com/b", "https://example.com/", "ERROR:URLError"),
+    ]
+
+    def test_excluded_codes_counted_correctly(self):
+        """Codes not matching the filter appear in excluded_summary with correct counts."""
+        filter_obj = sf.build_filter("404,500")
+        excluded = filter_obj.excluded_summary(self._RESULTS)
+        self.assertIn("200", excluded)
+        self.assertEqual(excluded["200"], 1)
+        self.assertIn("301", excluded)
+        self.assertEqual(excluded["301"], 1)
+
+    def test_matching_codes_not_in_excluded_summary(self):
+        """Codes matching the filter do not appear in excluded_summary."""
+        filter_obj = sf.build_filter("404,500")
+        excluded = filter_obj.excluded_summary(self._RESULTS)
+        self.assertNotIn("404", excluded)
+        self.assertNotIn("500", excluded)
+        self.assertNotIn("ERROR:URLError", excluded)
+
+    def test_empty_results_returns_empty_summary(self):
+        """An empty results list produces an empty excluded_summary."""
+        filter_obj = sf.build_filter("404,500")
+        self.assertEqual(filter_obj.excluded_summary([]), {})
+
+    def test_all_matching_returns_empty_summary(self):
+        """When all results match the filter, excluded_summary is empty."""
+        filter_obj = sf.build_filter("404,500")
+        results = [
+            ("https://example.com/a", "", "404"),
+            ("https://example.com/b", "", "500"),
+            ("https://example.com/c", "", "ERROR:URLError"),
+        ]
+        self.assertEqual(filter_obj.excluded_summary(results), {})
+
+    def test_multiple_occurrences_summed(self):
+        """Multiple rows with the same excluded code sum to a single entry."""
+        filter_obj = sf.build_filter("404")
+        results = [
+            ("https://example.com/a", "", "200"),
+            ("https://example.com/b", "", "200"),
+            ("https://example.com/c", "", "200"),
+        ]
+        excluded = filter_obj.excluded_summary(results)
+        self.assertEqual(excluded.get("200"), 3)
+
+    def test_empty_filter_produces_empty_summary(self):
+        """With an empty filter (no filtering), excluded_summary is always empty."""
+        filter_obj = sf.build_filter("")
+        excluded = filter_obj.excluded_summary(self._RESULTS)
+        self.assertEqual(excluded, {})
+
+
+# ---------------------------------------------------------------------------
+# build_filter factory
+# ---------------------------------------------------------------------------
+
+class TestBuildFilter(unittest.TestCase):
+    """Tests for status_filter.build_filter()."""
+
+    def test_default_codes_parsed_correctly(self):
+        """'404,500' builds a filter matching 404 and 500."""
+        filter_obj = sf.build_filter("404,500")
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("500"))
+        self.assertFalse(filter_obj.matches("200"))
+
+    def test_empty_string_builds_no_filter(self):
+        """An empty string builds a filter that matches everything."""
+        filter_obj = sf.build_filter("")
+        self.assertTrue(filter_obj.matches("200"))
+        self.assertTrue(filter_obj.matches("404"))
+
+    def test_include_3xx_compat_false_by_default(self):
+        """include_3xx_compat defaults to False."""
+        filter_obj = sf.build_filter("404,500")
+        self.assertFalse(filter_obj.matches("301"))
+
+    def test_include_3xx_compat_true_includes_3xx(self):
+        """include_3xx_compat=True makes 3xx codes match."""
+        filter_obj = sf.build_filter("404,500", include_3xx_compat=True)
+        self.assertTrue(filter_obj.matches("301"))
+
+    def test_custom_codes(self):
+        """Custom code list is respected."""
+        filter_obj = sf.build_filter("403,404,500")
+        self.assertTrue(filter_obj.matches("403"))
+        self.assertFalse(filter_obj.matches("200"))
+
+    def test_codes_with_spaces_stripped(self):
+        """Spaces around commas are stripped."""
+        filter_obj = sf.build_filter(" 404 , 500 ")
+        self.assertTrue(filter_obj.matches("404"))
+        self.assertTrue(filter_obj.matches("500"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `--keep-status-codes` CLI parameter (default: `404,500`) controlling which HTTP status codes appear in CSV, Markdown, and email output
- `ERROR:*` rows always pass through regardless of the filter; an empty value disables filtering entirely
- Email notification gains an excluded-codes count summary section listing codes filtered out
- Deprecates `--include-3xx-status-code`: emits a stderr warning; when used alone (without `--keep-status-codes`) it expands the default filter to include 3xx codes for backward compatibility
- New `src/status_filter.py` module with `StatusFilter` domain type

## Test plan

- [x] 175 tests pass (unit + integration)
- [x] New `tests/test_status_filter.py` covers `StatusFilter.matches()`, `excluded_summary()`, `build_filter()`
- [x] Updated `tests/test_issue_35_include_3xx.py` covers deprecation warning, backward compat, new flag precedence
- [x] Integration test updated: 200 excluded by default filter; no-filter run verifies 200 appears
- [x] Bug fixed: empty `--keep-status-codes ""` correctly disables filter (was coerced to default via `or`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)